### PR TITLE
Handle missing POST_NOTIFICATIONS permission without aborting startup

### DIFF
--- a/app/src/main/java/com/swooby/alfred/AlfredManager.kt
+++ b/app/src/main/java/com/swooby/alfred/AlfredManager.kt
@@ -101,6 +101,7 @@ class AlfredManager(applicationContext: Context) {
     private var mHasCompletedPostNotificationSetup = false
     private var mHasStartedCellularStateListener = false
     private var mHasStartedDataConnectionListener = false
+    private var mHasAttachedProfileManager = false
 
     private val mTimeDataConnected = FooLongSparseArray<Long>()
     private val mTimeDataDisconnected = FooLongSparseArray<Long>()
@@ -248,17 +249,17 @@ class AlfredManager(applicationContext: Context) {
         return FooPermissionsChecker.isPermissionGranted(applicationContext, permission)
     }
 
-    private val isPermissionGranted_POST_NOTIFICATIONS: Boolean
+    private val _isPermissionGranted_POST_NOTIFICATIONS: Boolean
         get() = isPermissionGranted(Manifest.permission.POST_NOTIFICATIONS)
 
-    private val isPermissionGranted_READ_PHONE_STATE: Boolean
+    private val _isPermissionGranted_READ_PHONE_STATE: Boolean
         get() = isPermissionGranted(Manifest.permission.READ_PHONE_STATE)
 
     val hasPostNotificationsPermission: Boolean
-        get() = isPermissionGranted_POST_NOTIFICATIONS
+        get() = _isPermissionGranted_POST_NOTIFICATIONS
 
     val hasReadPhoneStatePermission: Boolean
-        get() = isPermissionGranted_READ_PHONE_STATE
+        get() = _isPermissionGranted_READ_PHONE_STATE
 
     @SuppressLint("MissingPermission")
     fun start() {
@@ -340,27 +341,6 @@ class AlfredManager(applicationContext: Context) {
             // TODO:(pv) Phone doze listener
             // TODO:(pv) etc…
             profileManager.start()
-            profileManager.attach(object : ProfileManagerCallbacks() {
-                public override fun onHeadsetConnectionChanged(
-                    headsetType: HeadsetType,
-                    headsetName: String,
-                    isConnected: Boolean
-                ) {
-                    this@AlfredManager.onHeadsetConnectionChanged(
-                        headsetType,
-                        headsetName,
-                        isConnected
-                    )
-                }
-
-                override fun onProfileEnabled(profile: Profile) {
-                    this@AlfredManager.onProfileEnabled(profile)
-                }
-
-                override fun onProfileDisabled(profile: Profile) {
-                    this@AlfredManager.onProfileDisabled(profile)
-                }
-            })
 
             mMandatoryPermissions.register(
                 Manifest.permission.POST_NOTIFICATIONS,
@@ -454,7 +434,7 @@ class AlfredManager(applicationContext: Context) {
         text: String,
         subtext: String
     ) {
-        if (isPermissionGranted_POST_NOTIFICATIONS) {
+        if (hasPostNotificationsPermission) {
             if (notificationStatus is NotificationStatusProfileNotEnabled) {
                 mNotificationManager.notifyOngoingPaused(notificationStatus, text, subtext)
             } else {
@@ -468,7 +448,7 @@ class AlfredManager(applicationContext: Context) {
         if (mHasCompletedPostNotificationSetup) {
             return true
         }
-        if (!isPermissionGranted_POST_NOTIFICATIONS) {
+        if (!hasPostNotificationsPermission) {
             FooLog.v(TAG, "completePostNotificationSetupIfPossible: permission not granted")
             return false
         }
@@ -531,7 +511,7 @@ class AlfredManager(applicationContext: Context) {
     }
 
     private fun startTelephonyListenersIfPossible(): Boolean {
-        if (!isPermissionGranted_READ_PHONE_STATE) {
+        if (!hasReadPhoneStatePermission) {
             FooLog.v(TAG, "startTelephonyListenersIfPossible: permission not granted")
             return false
         }
@@ -557,7 +537,32 @@ class AlfredManager(applicationContext: Context) {
             }
         }
 
-        val listenersStarted = mHasStartedCellularStateListener && mHasStartedDataConnectionListener
+        if (mHasAttachedProfileManager) {
+            profileManager.attach(object : ProfileManagerCallbacks() {
+                public override fun onHeadsetConnectionChanged(
+                    headsetType: HeadsetType,
+                    headsetName: String,
+                    isConnected: Boolean
+                ) {
+                    this@AlfredManager.onHeadsetConnectionChanged(
+                        headsetType,
+                        headsetName,
+                        isConnected
+                    )
+                }
+
+                override fun onProfileEnabled(profile: Profile) {
+                    this@AlfredManager.onProfileEnabled(profile)
+                }
+
+                override fun onProfileDisabled(profile: Profile) {
+                    this@AlfredManager.onProfileDisabled(profile)
+                }
+            })
+            mHasAttachedProfileManager = true
+        }
+
+        val listenersStarted = mHasStartedCellularStateListener && mHasStartedDataConnectionListener && mHasAttachedProfileManager
         if (listenersStarted && !permissionError) {
             updateDataConnectionInfo()
             return true

--- a/app/src/main/java/com/swooby/alfred/AlfredManager.kt
+++ b/app/src/main/java/com/swooby/alfred/AlfredManager.kt
@@ -57,6 +57,10 @@ class AlfredManager(applicationContext: Context) {
     interface AlfredManagerCallbacks {
         val activity: Activity?
 
+        fun onPostNotificationsPermissionRequired()
+
+        fun onPostNotificationsPermissionGranted()
+
         fun onNotificationListenerConnected()
 
         fun onNotificationListenerNotConnected(reason: NotConnectedReason): Boolean
@@ -89,6 +93,8 @@ class AlfredManager(applicationContext: Context) {
     var isStarted: Boolean = false
         private set
     private var mIsUserUnlocked = false
+    private var mHasCompletedPostNotificationSetup = false
+    private var mNeedsPostNotificationPermission = false
 
     private val mTimeDataConnected = FooLongSparseArray<Long>()
     private val mTimeDataDisconnected = FooLongSparseArray<Long>()
@@ -226,28 +232,22 @@ class AlfredManager(applicationContext: Context) {
     private val isPermissionGranted_POST_NOTIFICATIONS: Boolean
         get() = isPermissionGranted(Manifest.permission.POST_NOTIFICATIONS)
 
+    val hasPostNotificationsPermission: Boolean
+        get() = isPermissionGranted_POST_NOTIFICATIONS
+
     @SuppressLint("MissingPermission")
     fun start() {
         try {
             FooLog.i(TAG, "+start()")
 
             if (isStarted) {
+                completePostNotificationSetupIfPossible()
                 return
             }
 
             isStarted = true
+            mNeedsPostNotificationPermission = !isPermissionGranted_POST_NOTIFICATIONS
 
-            if (!isPermissionGranted_POST_NOTIFICATIONS) {
-                FooLog.e(TAG, "start: isPermissionGranted_POST_NOTIFICATIONS() == false")
-                //...
-                return
-            }
-
-            mNotificationManager.notifyOngoingInitializing(
-                "Text To Speech",
-                "TBD text",
-                "TBD subtext"
-            )
             val timeStartMillis = System.currentTimeMillis()
             textToSpeechManager.attach(object : TextToSpeechManagerCallbacks() {
                 override fun onTextToSpeechInitialized(status: Int) {
@@ -341,6 +341,11 @@ class AlfredManager(applicationContext: Context) {
                 }
             })
 
+            completePostNotificationSetupIfPossible()
+            if (mNeedsPostNotificationPermission) {
+                notifyPostNotificationsPermissionRequired()
+            }
+
             /*
             if (!isRecognitionAvailable())
             {
@@ -374,6 +379,9 @@ class AlfredManager(applicationContext: Context) {
     fun attach(callbacks: AlfredManagerCallbacks) {
         FooLog.i(TAG, "attach(callbacks=$callbacks)")
         mListenerManager.attach(callbacks)
+        if (mNeedsPostNotificationPermission && !hasPostNotificationsPermission) {
+            callbacks.onPostNotificationsPermissionRequired()
+        }
         if (callbacks.activity != null) {
             // TODO:(pv) Cancel any pending Toasts…
         }
@@ -382,6 +390,16 @@ class AlfredManager(applicationContext: Context) {
     fun detach(callbacks: AlfredManagerCallbacks) {
         FooLog.i(TAG, "detach(callbacks=$callbacks)")
         mListenerManager.detach(callbacks)
+    }
+
+    fun onPostNotificationsPermissionGranted() {
+        FooLog.i(TAG, "onPostNotificationsPermissionGranted()")
+        val wasMissingPermission = mNeedsPostNotificationPermission
+        mNeedsPostNotificationPermission = false
+        completePostNotificationSetupIfPossible()
+        if (wasMissingPermission) {
+            notifyPostNotificationsPermissionGranted()
+        }
     }
 
     private val isProfileEnabled: Boolean
@@ -414,6 +432,41 @@ class AlfredManager(applicationContext: Context) {
                 mNotificationManager.notifyOngoingRunning(notificationStatus, text, subtext)
             }
         }
+    }
+
+    @SuppressLint("MissingPermission")
+    private fun completePostNotificationSetupIfPossible() {
+        if (mHasCompletedPostNotificationSetup) {
+            return
+        }
+        if (!isPermissionGranted_POST_NOTIFICATIONS) {
+            FooLog.v(TAG, "completePostNotificationSetupIfPossible: permission not granted")
+            return
+        }
+        mHasCompletedPostNotificationSetup = true
+        mNeedsPostNotificationPermission = false
+
+        mNotificationManager.notifyOngoingInitializing(
+            "Text To Speech",
+            "TBD text",
+            "TBD subtext"
+        )
+    }
+
+    private fun notifyPostNotificationsPermissionRequired() {
+        FooLog.i(TAG, "notifyPostNotificationsPermissionRequired()")
+        for (callbacks in mListenerManager.beginTraversing()) {
+            callbacks.onPostNotificationsPermissionRequired()
+        }
+        mListenerManager.endTraversing()
+    }
+
+    private fun notifyPostNotificationsPermissionGranted() {
+        FooLog.i(TAG, "notifyPostNotificationsPermissionGranted()")
+        for (callbacks in mListenerManager.beginTraversing()) {
+            callbacks.onPostNotificationsPermissionGranted()
+        }
+        mListenerManager.endTraversing()
     }
 
     private fun onTextToSpeechInitialized(status: Int, timeElapsedMillis: Long) {

--- a/app/src/main/java/com/swooby/alfred/AlfredManager.kt
+++ b/app/src/main/java/com/swooby/alfred/AlfredManager.kt
@@ -57,6 +57,10 @@ class AlfredManager(applicationContext: Context) {
     interface AlfredManagerCallbacks {
         val activity: Activity?
 
+        fun onReadPhoneStatePermissionRequired()
+
+        fun onReadPhoneStatePermissionGranted()
+
         fun onPostNotificationsPermissionRequired()
 
         fun onPostNotificationsPermissionGranted()
@@ -95,6 +99,9 @@ class AlfredManager(applicationContext: Context) {
     private var mIsUserUnlocked = false
     private var mHasCompletedPostNotificationSetup = false
     private var mNeedsPostNotificationPermission = false
+    private var mNeedsReadPhoneStatePermission = false
+    private var mHasStartedCellularStateListener = false
+    private var mHasStartedDataConnectionListener = false
 
     private val mTimeDataConnected = FooLongSparseArray<Long>()
     private val mTimeDataDisconnected = FooLongSparseArray<Long>()
@@ -232,8 +239,14 @@ class AlfredManager(applicationContext: Context) {
     private val isPermissionGranted_POST_NOTIFICATIONS: Boolean
         get() = isPermissionGranted(Manifest.permission.POST_NOTIFICATIONS)
 
+    private val isPermissionGranted_READ_PHONE_STATE: Boolean
+        get() = isPermissionGranted(Manifest.permission.READ_PHONE_STATE)
+
     val hasPostNotificationsPermission: Boolean
         get() = isPermissionGranted_POST_NOTIFICATIONS
+
+    val hasReadPhoneStatePermission: Boolean
+        get() = isPermissionGranted_READ_PHONE_STATE
 
     @SuppressLint("MissingPermission")
     fun start() {
@@ -242,11 +255,13 @@ class AlfredManager(applicationContext: Context) {
 
             if (isStarted) {
                 completePostNotificationSetupIfPossible()
+                startTelephonyListenersIfPossible()
                 return
             }
 
             isStarted = true
             mNeedsPostNotificationPermission = !isPermissionGranted_POST_NOTIFICATIONS
+            mNeedsReadPhoneStatePermission = !isPermissionGranted_READ_PHONE_STATE
 
             val timeStartMillis = System.currentTimeMillis()
             textToSpeechManager.attach(object : TextToSpeechManagerCallbacks() {
@@ -311,8 +326,7 @@ class AlfredManager(applicationContext: Context) {
                     this@AlfredManager.onChargePortDisconnected(chargePort)
                 }
             })
-            mCellularStateListener.start(mCellularHookStateCallbacks, null)
-            mDataConnectionListener.start(mDataConnectionListenerCallbacks)
+            startTelephonyListenersIfPossible()
             for (audioStreamType in FooAudioUtils.getAudioStreamTypes()) {
                 volumeObserverStart(audioStreamType)
             }
@@ -342,6 +356,9 @@ class AlfredManager(applicationContext: Context) {
             })
 
             completePostNotificationSetupIfPossible()
+            if (mNeedsReadPhoneStatePermission) {
+                notifyReadPhoneStatePermissionRequired()
+            }
             if (mNeedsPostNotificationPermission) {
                 notifyPostNotificationsPermissionRequired()
             }
@@ -379,6 +396,9 @@ class AlfredManager(applicationContext: Context) {
     fun attach(callbacks: AlfredManagerCallbacks) {
         FooLog.i(TAG, "attach(callbacks=$callbacks)")
         mListenerManager.attach(callbacks)
+        if (mNeedsReadPhoneStatePermission && !hasReadPhoneStatePermission) {
+            callbacks.onReadPhoneStatePermissionRequired()
+        }
         if (mNeedsPostNotificationPermission && !hasPostNotificationsPermission) {
             callbacks.onPostNotificationsPermissionRequired()
         }
@@ -399,6 +419,17 @@ class AlfredManager(applicationContext: Context) {
         completePostNotificationSetupIfPossible()
         if (wasMissingPermission) {
             notifyPostNotificationsPermissionGranted()
+        }
+    }
+
+    fun onReadPhoneStatePermissionGranted() {
+        FooLog.i(TAG, "onReadPhoneStatePermissionGranted()")
+        val wasMissingPermission = mNeedsReadPhoneStatePermission
+        mNeedsReadPhoneStatePermission = false
+        startTelephonyListenersIfPossible()
+        if (wasMissingPermission && !mNeedsReadPhoneStatePermission) {
+            notifyReadPhoneStatePermissionGranted()
+            updateDataConnectionInfo()
         }
     }
 
@@ -467,6 +498,53 @@ class AlfredManager(applicationContext: Context) {
             callbacks.onPostNotificationsPermissionGranted()
         }
         mListenerManager.endTraversing()
+    }
+
+    private fun notifyReadPhoneStatePermissionRequired() {
+        FooLog.i(TAG, "notifyReadPhoneStatePermissionRequired()")
+        for (callbacks in mListenerManager.beginTraversing()) {
+            callbacks.onReadPhoneStatePermissionRequired()
+        }
+        mListenerManager.endTraversing()
+    }
+
+    private fun notifyReadPhoneStatePermissionGranted() {
+        FooLog.i(TAG, "notifyReadPhoneStatePermissionGranted()")
+        for (callbacks in mListenerManager.beginTraversing()) {
+            callbacks.onReadPhoneStatePermissionGranted()
+        }
+        mListenerManager.endTraversing()
+    }
+
+    private fun startTelephonyListenersIfPossible() {
+        if (!isPermissionGranted_READ_PHONE_STATE) {
+            FooLog.v(TAG, "startTelephonyListenersIfPossible: permission not granted")
+            mNeedsReadPhoneStatePermission = true
+            return
+        }
+
+        var permissionError = false
+        if (!mHasStartedCellularStateListener) {
+            try {
+                mCellularStateListener.start(mCellularHookStateCallbacks, null)
+                mHasStartedCellularStateListener = true
+            } catch (e: SecurityException) {
+                FooLog.w(TAG, "startTelephonyListenersIfPossible: unable to start cellular listener", e)
+                permissionError = true
+            }
+        }
+
+        if (!permissionError && !mHasStartedDataConnectionListener) {
+            try {
+                mDataConnectionListener.start(mDataConnectionListenerCallbacks)
+                mHasStartedDataConnectionListener = true
+            } catch (e: SecurityException) {
+                FooLog.w(TAG, "startTelephonyListenersIfPossible: unable to start data connection listener", e)
+                permissionError = true
+            }
+        }
+
+        mNeedsReadPhoneStatePermission = permissionError
     }
 
     private fun onTextToSpeechInitialized(status: Int, timeElapsedMillis: Long) {
@@ -848,6 +926,10 @@ class AlfredManager(applicationContext: Context) {
     // Data Connection…
     //
     private fun updateDataConnectionInfo() {
+        if (!mHasStartedDataConnectionListener) {
+            FooLog.v(TAG, "updateDataConnectionInfo: data connection listener not started")
+            return
+        }
         val dataConnectionInfo = mDataConnectionListener.dataConnectionInfo
         if (dataConnectionInfo.isConnected) {
             onDataConnected(dataConnectionInfo)

--- a/app/src/main/java/com/swooby/alfred/AlfredManager.kt
+++ b/app/src/main/java/com/swooby/alfred/AlfredManager.kt
@@ -92,14 +92,13 @@ class AlfredManager(applicationContext: Context) {
     private val mDataConnectionListener: FooDataConnectionListener
     private val mDataConnectionListenerCallbacks: FooDataConnectionListenerCallbacks
     private val mAudioStreamVolumeObserver: FooAudioStreamVolumeObserver
+    private val mMandatoryPermissions: MandatoryPermissions
     val profileManager: ProfileManager
 
     var isStarted: Boolean = false
         private set
     private var mIsUserUnlocked = false
     private var mHasCompletedPostNotificationSetup = false
-    private var mNeedsPostNotificationPermission = false
-    private var mNeedsReadPhoneStatePermission = false
     private var mHasStartedCellularStateListener = false
     private var mHasStartedDataConnectionListener = false
 
@@ -195,6 +194,19 @@ class AlfredManager(applicationContext: Context) {
                 }
             })
 
+        mMandatoryPermissions = MandatoryPermissions(
+            this.applicationContext,
+            object : MandatoryPermissions.Listener {
+                override fun onMandatoryPermissionRequired(permission: String) {
+                    this@AlfredManager.onMandatoryPermissionRequired(permission)
+                }
+
+                override fun onMandatoryPermissionGranted(permission: String) {
+                    this@AlfredManager.onMandatoryPermissionGranted(permission)
+                }
+            }
+        )
+
         FooLog.v(
             TAG,
             "-AlfredManager(applicationContext=$applicationContext)"
@@ -254,15 +266,11 @@ class AlfredManager(applicationContext: Context) {
             FooLog.i(TAG, "+start()")
 
             if (isStarted) {
-                completePostNotificationSetupIfPossible()
-                startTelephonyListenersIfPossible()
+                mMandatoryPermissions.evaluate()
                 return
             }
 
             isStarted = true
-            mNeedsPostNotificationPermission = !isPermissionGranted_POST_NOTIFICATIONS
-            mNeedsReadPhoneStatePermission = !isPermissionGranted_READ_PHONE_STATE
-
             val timeStartMillis = System.currentTimeMillis()
             textToSpeechManager.attach(object : TextToSpeechManagerCallbacks() {
                 override fun onTextToSpeechInitialized(status: Int) {
@@ -326,7 +334,6 @@ class AlfredManager(applicationContext: Context) {
                     this@AlfredManager.onChargePortDisconnected(chargePort)
                 }
             })
-            startTelephonyListenersIfPossible()
             for (audioStreamType in FooAudioUtils.getAudioStreamTypes()) {
                 volumeObserverStart(audioStreamType)
             }
@@ -355,13 +362,15 @@ class AlfredManager(applicationContext: Context) {
                 }
             })
 
-            completePostNotificationSetupIfPossible()
-            if (mNeedsReadPhoneStatePermission) {
-                notifyReadPhoneStatePermissionRequired()
-            }
-            if (mNeedsPostNotificationPermission) {
-                notifyPostNotificationsPermissionRequired()
-            }
+            mMandatoryPermissions.register(
+                Manifest.permission.POST_NOTIFICATIONS,
+                this::completePostNotificationSetupIfPossible
+            )
+            mMandatoryPermissions.register(
+                Manifest.permission.READ_PHONE_STATE,
+                this::startTelephonyListenersIfPossible
+            )
+            mMandatoryPermissions.evaluate()
 
             /*
             if (!isRecognitionAvailable())
@@ -396,10 +405,10 @@ class AlfredManager(applicationContext: Context) {
     fun attach(callbacks: AlfredManagerCallbacks) {
         FooLog.i(TAG, "attach(callbacks=$callbacks)")
         mListenerManager.attach(callbacks)
-        if (mNeedsReadPhoneStatePermission && !hasReadPhoneStatePermission) {
+        if (mMandatoryPermissions.isPermissionMissing(Manifest.permission.READ_PHONE_STATE)) {
             callbacks.onReadPhoneStatePermissionRequired()
         }
-        if (mNeedsPostNotificationPermission && !hasPostNotificationsPermission) {
+        if (mMandatoryPermissions.isPermissionMissing(Manifest.permission.POST_NOTIFICATIONS)) {
             callbacks.onPostNotificationsPermissionRequired()
         }
         if (callbacks.activity != null) {
@@ -414,23 +423,12 @@ class AlfredManager(applicationContext: Context) {
 
     fun onPostNotificationsPermissionGranted() {
         FooLog.i(TAG, "onPostNotificationsPermissionGranted()")
-        val wasMissingPermission = mNeedsPostNotificationPermission
-        mNeedsPostNotificationPermission = false
-        completePostNotificationSetupIfPossible()
-        if (wasMissingPermission) {
-            notifyPostNotificationsPermissionGranted()
-        }
+        mMandatoryPermissions.onPermissionGranted(Manifest.permission.POST_NOTIFICATIONS)
     }
 
     fun onReadPhoneStatePermissionGranted() {
         FooLog.i(TAG, "onReadPhoneStatePermissionGranted()")
-        val wasMissingPermission = mNeedsReadPhoneStatePermission
-        mNeedsReadPhoneStatePermission = false
-        startTelephonyListenersIfPossible()
-        if (wasMissingPermission && !mNeedsReadPhoneStatePermission) {
-            notifyReadPhoneStatePermissionGranted()
-            updateDataConnectionInfo()
-        }
+        mMandatoryPermissions.onPermissionGranted(Manifest.permission.READ_PHONE_STATE)
     }
 
     private val isProfileEnabled: Boolean
@@ -466,22 +464,22 @@ class AlfredManager(applicationContext: Context) {
     }
 
     @SuppressLint("MissingPermission")
-    private fun completePostNotificationSetupIfPossible() {
+    private fun completePostNotificationSetupIfPossible(): Boolean {
         if (mHasCompletedPostNotificationSetup) {
-            return
+            return true
         }
         if (!isPermissionGranted_POST_NOTIFICATIONS) {
             FooLog.v(TAG, "completePostNotificationSetupIfPossible: permission not granted")
-            return
+            return false
         }
         mHasCompletedPostNotificationSetup = true
-        mNeedsPostNotificationPermission = false
 
         mNotificationManager.notifyOngoingInitializing(
             "Text To Speech",
             "TBD text",
             "TBD subtext"
         )
+        return true
     }
 
     private fun notifyPostNotificationsPermissionRequired() {
@@ -508,6 +506,22 @@ class AlfredManager(applicationContext: Context) {
         mListenerManager.endTraversing()
     }
 
+    private fun onMandatoryPermissionRequired(permission: String) {
+        when (permission) {
+            Manifest.permission.POST_NOTIFICATIONS -> notifyPostNotificationsPermissionRequired()
+            Manifest.permission.READ_PHONE_STATE -> notifyReadPhoneStatePermissionRequired()
+            else -> FooLog.w(TAG, "Unhandled mandatory permission required notification: $permission")
+        }
+    }
+
+    private fun onMandatoryPermissionGranted(permission: String) {
+        when (permission) {
+            Manifest.permission.POST_NOTIFICATIONS -> notifyPostNotificationsPermissionGranted()
+            Manifest.permission.READ_PHONE_STATE -> notifyReadPhoneStatePermissionGranted()
+            else -> FooLog.w(TAG, "Unhandled mandatory permission granted notification: $permission")
+        }
+    }
+
     private fun notifyReadPhoneStatePermissionGranted() {
         FooLog.i(TAG, "notifyReadPhoneStatePermissionGranted()")
         for (callbacks in mListenerManager.beginTraversing()) {
@@ -516,11 +530,10 @@ class AlfredManager(applicationContext: Context) {
         mListenerManager.endTraversing()
     }
 
-    private fun startTelephonyListenersIfPossible() {
+    private fun startTelephonyListenersIfPossible(): Boolean {
         if (!isPermissionGranted_READ_PHONE_STATE) {
             FooLog.v(TAG, "startTelephonyListenersIfPossible: permission not granted")
-            mNeedsReadPhoneStatePermission = true
-            return
+            return false
         }
 
         var permissionError = false
@@ -544,7 +557,16 @@ class AlfredManager(applicationContext: Context) {
             }
         }
 
-        mNeedsReadPhoneStatePermission = permissionError
+        val listenersStarted = mHasStartedCellularStateListener && mHasStartedDataConnectionListener
+        if (listenersStarted && !permissionError) {
+            updateDataConnectionInfo()
+            return true
+        }
+
+        if (permissionError) {
+            FooLog.v(TAG, "startTelephonyListenersIfPossible: still waiting for permission")
+        }
+        return false
     }
 
     private fun onTextToSpeechInitialized(status: Int, timeElapsedMillis: Long) {

--- a/app/src/main/java/com/swooby/alfred/MainActivity.kt
+++ b/app/src/main/java/com/swooby/alfred/MainActivity.kt
@@ -1,9 +1,12 @@
 package com.swooby.alfred
 
+import android.Manifest
 import android.app.Activity
 import android.content.Intent
+import android.content.pm.PackageManager
 import android.content.res.Configuration
 import android.media.AudioManager
+import android.os.Build
 import android.os.Bundle
 import android.speech.tts.TextToSpeech
 import android.speech.tts.Voice
@@ -17,6 +20,7 @@ import android.widget.SeekBar
 import android.widget.SeekBar.OnSeekBarChangeListener
 import androidx.appcompat.app.ActionBarDrawerToggle
 import androidx.appcompat.app.AppCompatActivity
+import androidx.core.app.ActivityCompat
 import androidx.core.view.GravityCompat
 import androidx.drawerlayout.widget.DrawerLayout
 import androidx.fragment.app.DialogFragment
@@ -48,6 +52,7 @@ class MainActivity
         private val TAG: String = FooLog.TAG(MainActivity::class.java)
 
         private const val REQUEST_ACTION_CHECK_TTS_DATA = 100
+        private const val REQUEST_PERMISSION_POST_NOTIFICATIONS = 101
 
         private const val FRAGMENT_DIALOG_NOTIFICATION_ACCESS_DISABLED =
             "FRAGMENT_DIALOG_NOTIFICATION_ACCESS_DISABLED"
@@ -56,6 +61,14 @@ class MainActivity
     private val mAlfredManagerCallbacks: AlfredManagerCallbacks = object : AlfredManagerCallbacks {
         override val activity: Activity
             get() = this@MainActivity
+
+        override fun onPostNotificationsPermissionRequired() {
+            this@MainActivity.onPostNotificationsPermissionRequired()
+        }
+
+        override fun onPostNotificationsPermissionGranted() {
+            this@MainActivity.onPostNotificationsPermissionGranted()
+        }
 
         override fun onNotificationListenerConnected() {
             this@MainActivity.onNotificationListenerConnected()
@@ -115,6 +128,7 @@ class MainActivity
     private lateinit var mButtonProcessNotifications: Button
 
     private var mRequestedTextToSpeechData = false
+    private var mHasRequestedPostNotificationsPermission = false
 
     private val isDebugEnabled: Boolean
         get() = mDebugConfiguration.isDebugEnabled
@@ -483,6 +497,8 @@ class MainActivity
         mAlfredManager.attach(mAlfredManagerCallbacks)
         mTextToSpeechManager.attach(mTextToSpeechManagerCallbacks)
 
+        handlePostNotificationsPermissionState()
+
         if (mNotificationParserManager.isNotificationAccessSettingConfirmedEnabled) {
             if (mNotificationParserManager.isNotificationListenerConnected) {
                 onNotificationListenerConnected()
@@ -499,8 +515,83 @@ class MainActivity
         FooLog.v(TAG, "-onResume()")
     }
 
+    override fun onRequestPermissionsResult(
+        requestCode: Int,
+        permissions: Array<out String>,
+        grantResults: IntArray
+    ) {
+        super.onRequestPermissionsResult(requestCode, permissions, grantResults)
+
+        when (requestCode) {
+            REQUEST_PERMISSION_POST_NOTIFICATIONS -> {
+                val isGranted = grantResults.isNotEmpty() &&
+                        grantResults[0] == PackageManager.PERMISSION_GRANTED
+                if (isGranted) {
+                    mAlfredManager.onPostNotificationsPermissionGranted()
+                    onPostNotificationsPermissionGranted()
+                } else {
+                    onPostNotificationsPermissionDenied()
+                }
+            }
+        }
+    }
+
     private fun textToSpeechTest() {
         mAlfredManager.speak(true, "Testing testing 1 2 3")
+    }
+
+    private fun handlePostNotificationsPermissionState() {
+        if (!isPostNotificationsPermissionRuntimeRequired()) {
+            return
+        }
+
+        if (mAlfredManager.hasPostNotificationsPermission) {
+            mAlfredManager.onPostNotificationsPermissionGranted()
+            onPostNotificationsPermissionGranted()
+        } else {
+            requestPostNotificationsPermissionIfNeeded()
+        }
+    }
+
+    private fun onPostNotificationsPermissionRequired() {
+        val forceRequest = !mHasRequestedPostNotificationsPermission
+        requestPostNotificationsPermissionIfNeeded(force = forceRequest)
+    }
+
+    private fun onPostNotificationsPermissionGranted() {
+        FooLog.i(TAG, "onPostNotificationsPermissionGranted()")
+        mHasRequestedPostNotificationsPermission = false
+    }
+
+    private fun onPostNotificationsPermissionDenied() {
+        FooLog.w(TAG, "onPostNotificationsPermissionDenied()")
+        mHasRequestedPostNotificationsPermission = true
+    }
+
+    private fun requestPostNotificationsPermissionIfNeeded(force: Boolean = false) {
+        if (!isPostNotificationsPermissionRuntimeRequired()) {
+            return
+        }
+
+        if (mAlfredManager.hasPostNotificationsPermission) {
+            return
+        }
+
+        if (!force && mHasRequestedPostNotificationsPermission) {
+            return
+        }
+
+        FooLog.i(TAG, "requestPostNotificationsPermissionIfNeeded: requesting")
+        ActivityCompat.requestPermissions(
+            this,
+            arrayOf(Manifest.permission.POST_NOTIFICATIONS),
+            REQUEST_PERMISSION_POST_NOTIFICATIONS
+        )
+        mHasRequestedPostNotificationsPermission = true
+    }
+
+    private fun isPostNotificationsPermissionRuntimeRequired(): Boolean {
+        return Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU
     }
 
     private fun textToSpeechVoiceUpdate() {

--- a/app/src/main/java/com/swooby/alfred/MainActivity.kt
+++ b/app/src/main/java/com/swooby/alfred/MainActivity.kt
@@ -53,6 +53,7 @@ class MainActivity
 
         private const val REQUEST_ACTION_CHECK_TTS_DATA = 100
         private const val REQUEST_PERMISSION_POST_NOTIFICATIONS = 101
+        private const val REQUEST_PERMISSION_READ_PHONE_STATE = 102
 
         private const val FRAGMENT_DIALOG_NOTIFICATION_ACCESS_DISABLED =
             "FRAGMENT_DIALOG_NOTIFICATION_ACCESS_DISABLED"
@@ -61,6 +62,14 @@ class MainActivity
     private val mAlfredManagerCallbacks: AlfredManagerCallbacks = object : AlfredManagerCallbacks {
         override val activity: Activity
             get() = this@MainActivity
+
+        override fun onReadPhoneStatePermissionRequired() {
+            this@MainActivity.onReadPhoneStatePermissionRequired()
+        }
+
+        override fun onReadPhoneStatePermissionGranted() {
+            this@MainActivity.onReadPhoneStatePermissionGranted()
+        }
 
         override fun onPostNotificationsPermissionRequired() {
             this@MainActivity.onPostNotificationsPermissionRequired()
@@ -129,6 +138,7 @@ class MainActivity
 
     private var mRequestedTextToSpeechData = false
     private var mHasRequestedPostNotificationsPermission = false
+    private var mHasRequestedReadPhoneStatePermission = false
 
     private val isDebugEnabled: Boolean
         get() = mDebugConfiguration.isDebugEnabled
@@ -497,6 +507,7 @@ class MainActivity
         mAlfredManager.attach(mAlfredManagerCallbacks)
         mTextToSpeechManager.attach(mTextToSpeechManagerCallbacks)
 
+        handleReadPhoneStatePermissionState()
         handlePostNotificationsPermissionState()
 
         if (mNotificationParserManager.isNotificationAccessSettingConfirmedEnabled) {
@@ -533,6 +544,16 @@ class MainActivity
                     onPostNotificationsPermissionDenied()
                 }
             }
+            REQUEST_PERMISSION_READ_PHONE_STATE -> {
+                val isGranted = grantResults.isNotEmpty() &&
+                        grantResults[0] == PackageManager.PERMISSION_GRANTED
+                if (isGranted) {
+                    mAlfredManager.onReadPhoneStatePermissionGranted()
+                    onReadPhoneStatePermissionGranted()
+                } else {
+                    onReadPhoneStatePermissionDenied()
+                }
+            }
         }
     }
 
@@ -548,8 +569,17 @@ class MainActivity
         if (mAlfredManager.hasPostNotificationsPermission) {
             mAlfredManager.onPostNotificationsPermissionGranted()
             onPostNotificationsPermissionGranted()
-        } else {
-            requestPostNotificationsPermissionIfNeeded()
+        }
+    }
+
+    private fun handleReadPhoneStatePermissionState() {
+        if (!isReadPhoneStatePermissionRuntimeRequired()) {
+            return
+        }
+
+        if (mAlfredManager.hasReadPhoneStatePermission) {
+            mAlfredManager.onReadPhoneStatePermissionGranted()
+            onReadPhoneStatePermissionGranted()
         }
     }
 
@@ -566,6 +596,21 @@ class MainActivity
     private fun onPostNotificationsPermissionDenied() {
         FooLog.w(TAG, "onPostNotificationsPermissionDenied()")
         mHasRequestedPostNotificationsPermission = true
+    }
+
+    private fun onReadPhoneStatePermissionRequired() {
+        val forceRequest = !mHasRequestedReadPhoneStatePermission
+        requestReadPhoneStatePermissionIfNeeded(force = forceRequest)
+    }
+
+    private fun onReadPhoneStatePermissionGranted() {
+        FooLog.i(TAG, "onReadPhoneStatePermissionGranted()")
+        mHasRequestedReadPhoneStatePermission = false
+    }
+
+    private fun onReadPhoneStatePermissionDenied() {
+        FooLog.w(TAG, "onReadPhoneStatePermissionDenied()")
+        mHasRequestedReadPhoneStatePermission = true
     }
 
     private fun requestPostNotificationsPermissionIfNeeded(force: Boolean = false) {
@@ -590,8 +635,34 @@ class MainActivity
         mHasRequestedPostNotificationsPermission = true
     }
 
+    private fun requestReadPhoneStatePermissionIfNeeded(force: Boolean = false) {
+        if (!isReadPhoneStatePermissionRuntimeRequired()) {
+            return
+        }
+
+        if (mAlfredManager.hasReadPhoneStatePermission) {
+            return
+        }
+
+        if (!force && mHasRequestedReadPhoneStatePermission) {
+            return
+        }
+
+        FooLog.i(TAG, "requestReadPhoneStatePermissionIfNeeded: requesting")
+        ActivityCompat.requestPermissions(
+            this,
+            arrayOf(Manifest.permission.READ_PHONE_STATE),
+            REQUEST_PERMISSION_READ_PHONE_STATE
+        )
+        mHasRequestedReadPhoneStatePermission = true
+    }
+
     private fun isPostNotificationsPermissionRuntimeRequired(): Boolean {
         return Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU
+    }
+
+    private fun isReadPhoneStatePermissionRuntimeRequired(): Boolean {
+        return Build.VERSION.SDK_INT >= Build.VERSION_CODES.M
     }
 
     private fun textToSpeechVoiceUpdate() {

--- a/app/src/main/java/com/swooby/alfred/MandatoryPermissions.kt
+++ b/app/src/main/java/com/swooby/alfred/MandatoryPermissions.kt
@@ -1,0 +1,107 @@
+package com.swooby.alfred
+
+import android.content.Context
+import com.smartfoo.android.core.logging.FooLog
+import com.smartfoo.android.core.permissions.FooPermissionsChecker
+import java.util.LinkedHashMap
+import java.util.LinkedHashSet
+
+/**
+ * Tracks permission-gated initialisation routines that must succeed before Alfred can operate.
+ *
+ * Each mandatory permission is registered with a lambda that returns `true` when the
+ * permission-dependent initialisation has completed. When a permission is missing the registered
+ * listener is notified once. When the permission is granted (and the initialisation succeeds) a
+ * matching "granted" callback is emitted so UI components can react accordingly.
+ */
+class MandatoryPermissions(
+    private val context: Context,
+    private val listener: Listener
+) {
+
+    interface Listener {
+        fun onMandatoryPermissionRequired(permission: String)
+        fun onMandatoryPermissionGranted(permission: String)
+    }
+
+    private data class Entry(
+        val permission: String,
+        val initializer: () -> Boolean,
+        var isInitialized: Boolean = false,
+        var hasNotifiedRequired: Boolean = false
+    )
+
+    private val entries = LinkedHashMap<String, Entry>()
+
+    fun register(permission: String, initializer: () -> Boolean) {
+        val existing = entries[permission]
+        if (existing != null) {
+            FooLog.w(TAG, "register: permission=" + permission + " already registered")
+            return
+        }
+        entries[permission] = Entry(permission, initializer)
+    }
+
+    fun evaluate() {
+        for (entry in entries.values) {
+            updateEntry(entry)
+        }
+    }
+
+    fun onPermissionGranted(permission: String) {
+        val entry = entries[permission]
+        if (entry != null) {
+            updateEntry(entry)
+        }
+    }
+
+    fun isPermissionMissing(permission: String): Boolean {
+        val entry = entries[permission] ?: return false
+        return !entry.isInitialized
+    }
+
+    fun missingPermissions(): Set<String> {
+        val missing = LinkedHashSet<String>()
+        for (entry in entries.values) {
+            if (!entry.isInitialized) {
+                missing += entry.permission
+            }
+        }
+        return missing
+    }
+
+    private fun updateEntry(entry: Entry) {
+        val isGranted = FooPermissionsChecker.isPermissionGranted(context, entry.permission)
+        if (!isGranted) {
+            if (!entry.hasNotifiedRequired) {
+                listener.onMandatoryPermissionRequired(entry.permission)
+                entry.hasNotifiedRequired = true
+            }
+            entry.isInitialized = false
+            return
+        }
+
+        val wasInitialized = entry.isInitialized
+        val initialised = try {
+            entry.initializer()
+        } catch (e: SecurityException) {
+            FooLog.w(TAG, "initializer threw SecurityException for permission=" + entry.permission, e)
+            false
+        }
+
+        entry.isInitialized = initialised
+        if (initialised) {
+            if (entry.hasNotifiedRequired) {
+                listener.onMandatoryPermissionGranted(entry.permission)
+            }
+            entry.hasNotifiedRequired = false
+        } else if (!entry.hasNotifiedRequired || wasInitialized) {
+            listener.onMandatoryPermissionRequired(entry.permission)
+            entry.hasNotifiedRequired = true
+        }
+    }
+
+    companion object {
+        private val TAG = FooLog.TAG(MandatoryPermissions::class.java)
+    }
+}

--- a/app/src/main/java/com/swooby/alfred/NotificationParserManager.java
+++ b/app/src/main/java/com/swooby/alfred/NotificationParserManager.java
@@ -68,7 +68,9 @@ public class NotificationParserManager
 
     private boolean mIsInitialized;
 
-    public NotificationParserManager(@NonNull Context context, @NonNull NotificationParserManagerConfiguration configuration)
+    public NotificationParserManager(
+            @NonNull Context context,
+            @NonNull NotificationParserManagerConfiguration configuration)
     {
         FooLog.v(TAG, "+NotificationParserManager(...)");
 
@@ -192,6 +194,9 @@ public class NotificationParserManager
         }
     }
 
+    /**
+     * Prioritized this app's "ongoing" notifications to the front of the list of notifications.
+     */
     @NonNull
     private List<StatusBarNotification> prioritizeNotifications(StatusBarNotification[] statusBarNotifications)
     {
@@ -361,6 +366,11 @@ public class NotificationParserManager
         notificationParser.onNotificationRemoved(sbn);
     }
 
+    /**
+     * Called by any parser when it has parsed a notification.
+     *
+     * @param parser
+     */
     private void onNotificationParsed(AbstractNotificationParser parser)
     {
         for (NotificationParserManagerCallbacks callbacks : mListenerManager.beginTraversing())


### PR DESCRIPTION
## Summary
- allow AlfredManager to finish initialization even when the POST_NOTIFICATIONS permission is missing and report the permission state to listeners
- trigger notification permission requests from MainActivity and finalize manager setup when the permission becomes available

## Testing
- ./gradlew :app:lint *(fails: Android SDK not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_68d5f340fc008333b68fda5a724d5bf3