### PR TITLE
Gate profile manager setup on Bluetooth permission

### DIFF
--- a/app/src/main/java/com/swooby/alfred/AlfredManager.kt
+++ b/app/src/main/java/com/swooby/alfred/AlfredManager.kt
@@ -4,6 +4,7 @@ import android.Manifest
 import android.annotation.SuppressLint
 import android.app.Activity
 import android.content.Context
+import android.os.Build
 import android.os.Message
 import android.service.notification.StatusBarNotification
 import android.speech.tts.TextToSpeech
@@ -57,6 +58,18 @@ class AlfredManager(applicationContext: Context) {
     interface AlfredManagerCallbacks {
         val activity: Activity?
 
+        fun onReadPhoneStatePermissionRequired()
+
+        fun onReadPhoneStatePermissionGranted()
+
+        fun onBluetoothConnectPermissionRequired()
+
+        fun onBluetoothConnectPermissionGranted()
+
+        fun onPostNotificationsPermissionRequired()
+
+        fun onPostNotificationsPermissionGranted()
+
         fun onNotificationListenerConnected()
 
         fun onNotificationListenerNotConnected(reason: NotConnectedReason): Boolean
@@ -84,11 +97,18 @@ class AlfredManager(applicationContext: Context) {
     private val mDataConnectionListener: FooDataConnectionListener
     private val mDataConnectionListenerCallbacks: FooDataConnectionListenerCallbacks
     private val mAudioStreamVolumeObserver: FooAudioStreamVolumeObserver
+    private val mMandatoryPermissions: MandatoryPermissions
     val profileManager: ProfileManager
+    private val mProfileManagerCallbacks: ProfileManagerCallbacks
 
     var isStarted: Boolean = false
         private set
     private var mIsUserUnlocked = false
+    private var mHasCompletedPostNotificationSetup = false
+    private var mHasStartedProfileManager = false
+    private var mHasAttachedProfileManager = false
+    private var mHasStartedCellularStateListener = false
+    private var mHasStartedDataConnectionListener = false
 
     private val mTimeDataConnected = FooLongSparseArray<Long>()
     private val mTimeDataDisconnected = FooLongSparseArray<Long>()
@@ -181,6 +201,40 @@ class AlfredManager(applicationContext: Context) {
                     mAppPreferences.setProfileToken(profileToken)
                 }
             })
+        mProfileManagerCallbacks = object : ProfileManagerCallbacks() {
+            public override fun onHeadsetConnectionChanged(
+                headsetType: HeadsetType,
+                headsetName: String,
+                isConnected: Boolean
+            ) {
+                this@AlfredManager.onHeadsetConnectionChanged(
+                    headsetType,
+                    headsetName,
+                    isConnected
+                )
+            }
+
+            override fun onProfileEnabled(profile: Profile) {
+                this@AlfredManager.onProfileEnabled(profile)
+            }
+
+            override fun onProfileDisabled(profile: Profile) {
+                this@AlfredManager.onProfileDisabled(profile)
+            }
+        }
+
+        mMandatoryPermissions = MandatoryPermissions(
+            this.applicationContext,
+            object : MandatoryPermissions.Listener {
+                override fun onMandatoryPermissionRequired(permission: String) {
+                    this@AlfredManager.onMandatoryPermissionRequired(permission)
+                }
+
+                override fun onMandatoryPermissionGranted(permission: String) {
+                    this@AlfredManager.onMandatoryPermissionGranted(permission)
+                }
+            }
+        )
 
         FooLog.v(
             TAG,
@@ -226,28 +280,33 @@ class AlfredManager(applicationContext: Context) {
     private val isPermissionGranted_POST_NOTIFICATIONS: Boolean
         get() = isPermissionGranted(Manifest.permission.POST_NOTIFICATIONS)
 
+    private val isPermissionGranted_READ_PHONE_STATE: Boolean
+        get() = isPermissionGranted(Manifest.permission.READ_PHONE_STATE)
+
+    private val isPermissionGranted_BLUETOOTH_CONNECT: Boolean
+        get() = Build.VERSION.SDK_INT < Build.VERSION_CODES.S ||
+                isPermissionGranted(Manifest.permission.BLUETOOTH_CONNECT)
+
+    val hasPostNotificationsPermission: Boolean
+        get() = isPermissionGranted_POST_NOTIFICATIONS
+
+    val hasReadPhoneStatePermission: Boolean
+        get() = isPermissionGranted_READ_PHONE_STATE
+
+    val hasBluetoothConnectPermission: Boolean
+        get() = isPermissionGranted_BLUETOOTH_CONNECT
+
     @SuppressLint("MissingPermission")
     fun start() {
         try {
             FooLog.i(TAG, "+start()")
 
             if (isStarted) {
+                mMandatoryPermissions.evaluate()
                 return
             }
 
             isStarted = true
-
-            if (!isPermissionGranted_POST_NOTIFICATIONS) {
-                FooLog.e(TAG, "start: isPermissionGranted_POST_NOTIFICATIONS() == false")
-                //...
-                return
-            }
-
-            mNotificationManager.notifyOngoingInitializing(
-                "Text To Speech",
-                "TBD text",
-                "TBD subtext"
-            )
             val timeStartMillis = System.currentTimeMillis()
             textToSpeechManager.attach(object : TextToSpeechManagerCallbacks() {
                 override fun onTextToSpeechInitialized(status: Int) {
@@ -311,35 +370,30 @@ class AlfredManager(applicationContext: Context) {
                     this@AlfredManager.onChargePortDisconnected(chargePort)
                 }
             })
-            mCellularStateListener.start(mCellularHookStateCallbacks, null)
-            mDataConnectionListener.start(mDataConnectionListenerCallbacks)
             for (audioStreamType in FooAudioUtils.getAudioStreamTypes()) {
                 volumeObserverStart(audioStreamType)
             }
             // TODO:(pv) Phone doze listener
             // TODO:(pv) etc…
-            profileManager.start()
-            profileManager.attach(object : ProfileManagerCallbacks() {
-                public override fun onHeadsetConnectionChanged(
-                    headsetType: HeadsetType,
-                    headsetName: String,
-                    isConnected: Boolean
-                ) {
-                    this@AlfredManager.onHeadsetConnectionChanged(
-                        headsetType,
-                        headsetName,
-                        isConnected
-                    )
-                }
+            val requiresBluetoothPermission = Build.VERSION.SDK_INT >= Build.VERSION_CODES.S
+            if (requiresBluetoothPermission) {
+                mMandatoryPermissions.register(
+                    Manifest.permission.BLUETOOTH_CONNECT,
+                    this::startProfileManagerIfPossible
+                )
+            } else {
+                startProfileManagerIfPossible()
+            }
 
-                override fun onProfileEnabled(profile: Profile) {
-                    this@AlfredManager.onProfileEnabled(profile)
-                }
-
-                override fun onProfileDisabled(profile: Profile) {
-                    this@AlfredManager.onProfileDisabled(profile)
-                }
-            })
+            mMandatoryPermissions.register(
+                Manifest.permission.POST_NOTIFICATIONS,
+                this::completePostNotificationSetupIfPossible
+            )
+            mMandatoryPermissions.register(
+                Manifest.permission.READ_PHONE_STATE,
+                this::startTelephonyListenersIfPossible
+            )
+            mMandatoryPermissions.evaluate()
 
             /*
             if (!isRecognitionAvailable())
@@ -374,6 +428,17 @@ class AlfredManager(applicationContext: Context) {
     fun attach(callbacks: AlfredManagerCallbacks) {
         FooLog.i(TAG, "attach(callbacks=$callbacks)")
         mListenerManager.attach(callbacks)
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S &&
+            mMandatoryPermissions.isPermissionMissing(Manifest.permission.BLUETOOTH_CONNECT)
+        ) {
+            callbacks.onBluetoothConnectPermissionRequired()
+        }
+        if (mMandatoryPermissions.isPermissionMissing(Manifest.permission.READ_PHONE_STATE)) {
+            callbacks.onReadPhoneStatePermissionRequired()
+        }
+        if (mMandatoryPermissions.isPermissionMissing(Manifest.permission.POST_NOTIFICATIONS)) {
+            callbacks.onPostNotificationsPermissionRequired()
+        }
         if (callbacks.activity != null) {
             // TODO:(pv) Cancel any pending Toasts…
         }
@@ -382,6 +447,21 @@ class AlfredManager(applicationContext: Context) {
     fun detach(callbacks: AlfredManagerCallbacks) {
         FooLog.i(TAG, "detach(callbacks=$callbacks)")
         mListenerManager.detach(callbacks)
+    }
+
+    fun onPostNotificationsPermissionGranted() {
+        FooLog.i(TAG, "onPostNotificationsPermissionGranted()")
+        mMandatoryPermissions.onPermissionGranted(Manifest.permission.POST_NOTIFICATIONS)
+    }
+
+    fun onReadPhoneStatePermissionGranted() {
+        FooLog.i(TAG, "onReadPhoneStatePermissionGranted()")
+        mMandatoryPermissions.onPermissionGranted(Manifest.permission.READ_PHONE_STATE)
+    }
+
+    fun onBluetoothConnectPermissionGranted() {
+        FooLog.i(TAG, "onBluetoothConnectPermissionGranted()")
+        mMandatoryPermissions.onPermissionGranted(Manifest.permission.BLUETOOTH_CONNECT)
     }
 
     private val isProfileEnabled: Boolean
@@ -414,6 +494,159 @@ class AlfredManager(applicationContext: Context) {
                 mNotificationManager.notifyOngoingRunning(notificationStatus, text, subtext)
             }
         }
+    }
+
+    @SuppressLint("MissingPermission")
+    private fun completePostNotificationSetupIfPossible(): Boolean {
+        if (mHasCompletedPostNotificationSetup) {
+            return true
+        }
+        if (!isPermissionGranted_POST_NOTIFICATIONS) {
+            FooLog.v(TAG, "completePostNotificationSetupIfPossible: permission not granted")
+            return false
+        }
+        mHasCompletedPostNotificationSetup = true
+
+        mNotificationManager.notifyOngoingInitializing(
+            "Text To Speech",
+            "TBD text",
+            "TBD subtext"
+        )
+        return true
+    }
+
+    private fun notifyPostNotificationsPermissionRequired() {
+        FooLog.i(TAG, "notifyPostNotificationsPermissionRequired()")
+        for (callbacks in mListenerManager.beginTraversing()) {
+            callbacks.onPostNotificationsPermissionRequired()
+        }
+        mListenerManager.endTraversing()
+    }
+
+    private fun notifyPostNotificationsPermissionGranted() {
+        FooLog.i(TAG, "notifyPostNotificationsPermissionGranted()")
+        for (callbacks in mListenerManager.beginTraversing()) {
+            callbacks.onPostNotificationsPermissionGranted()
+        }
+        mListenerManager.endTraversing()
+    }
+
+    private fun notifyBluetoothConnectPermissionRequired() {
+        FooLog.i(TAG, "notifyBluetoothConnectPermissionRequired()")
+        for (callbacks in mListenerManager.beginTraversing()) {
+            callbacks.onBluetoothConnectPermissionRequired()
+        }
+        mListenerManager.endTraversing()
+    }
+
+    private fun notifyBluetoothConnectPermissionGranted() {
+        FooLog.i(TAG, "notifyBluetoothConnectPermissionGranted()")
+        for (callbacks in mListenerManager.beginTraversing()) {
+            callbacks.onBluetoothConnectPermissionGranted()
+        }
+        mListenerManager.endTraversing()
+    }
+
+    private fun notifyReadPhoneStatePermissionRequired() {
+        FooLog.i(TAG, "notifyReadPhoneStatePermissionRequired()")
+        for (callbacks in mListenerManager.beginTraversing()) {
+            callbacks.onReadPhoneStatePermissionRequired()
+        }
+        mListenerManager.endTraversing()
+    }
+
+    private fun onMandatoryPermissionRequired(permission: String) {
+        when (permission) {
+            Manifest.permission.POST_NOTIFICATIONS -> notifyPostNotificationsPermissionRequired()
+            Manifest.permission.READ_PHONE_STATE -> notifyReadPhoneStatePermissionRequired()
+            Manifest.permission.BLUETOOTH_CONNECT -> notifyBluetoothConnectPermissionRequired()
+            else -> FooLog.w(TAG, "Unhandled mandatory permission required notification: $permission")
+        }
+    }
+
+    private fun onMandatoryPermissionGranted(permission: String) {
+        when (permission) {
+            Manifest.permission.POST_NOTIFICATIONS -> notifyPostNotificationsPermissionGranted()
+            Manifest.permission.READ_PHONE_STATE -> notifyReadPhoneStatePermissionGranted()
+            Manifest.permission.BLUETOOTH_CONNECT -> notifyBluetoothConnectPermissionGranted()
+            else -> FooLog.w(TAG, "Unhandled mandatory permission granted notification: $permission")
+        }
+    }
+
+    private fun notifyReadPhoneStatePermissionGranted() {
+        FooLog.i(TAG, "notifyReadPhoneStatePermissionGranted()")
+        for (callbacks in mListenerManager.beginTraversing()) {
+            callbacks.onReadPhoneStatePermissionGranted()
+        }
+        mListenerManager.endTraversing()
+    }
+
+    private fun startProfileManagerIfPossible(): Boolean {
+        if (!isPermissionGranted_BLUETOOTH_CONNECT) {
+            FooLog.v(TAG, "startProfileManagerIfPossible: permission not granted")
+            return false
+        }
+
+        if (!mHasStartedProfileManager) {
+            try {
+                profileManager.start()
+                mHasStartedProfileManager = true
+            } catch (e: SecurityException) {
+                FooLog.w(TAG, "startProfileManagerIfPossible: unable to start profile manager", e)
+                return false
+            }
+        }
+
+        if (!mHasAttachedProfileManager) {
+            try {
+                profileManager.attach(mProfileManagerCallbacks)
+                mHasAttachedProfileManager = true
+            } catch (e: SecurityException) {
+                FooLog.w(TAG, "startProfileManagerIfPossible: unable to attach profile manager", e)
+                return false
+            }
+        }
+
+        return mHasStartedProfileManager && mHasAttachedProfileManager
+    }
+
+    private fun startTelephonyListenersIfPossible(): Boolean {
+        if (!isPermissionGranted_READ_PHONE_STATE) {
+            FooLog.v(TAG, "startTelephonyListenersIfPossible: permission not granted")
+            return false
+        }
+
+        var permissionError = false
+        if (!mHasStartedCellularStateListener) {
+            try {
+                mCellularStateListener.start(mCellularHookStateCallbacks, null)
+                mHasStartedCellularStateListener = true
+            } catch (e: SecurityException) {
+                FooLog.w(TAG, "startTelephonyListenersIfPossible: unable to start cellular listener", e)
+                permissionError = true
+            }
+        }
+
+        if (!permissionError && !mHasStartedDataConnectionListener) {
+            try {
+                mDataConnectionListener.start(mDataConnectionListenerCallbacks)
+                mHasStartedDataConnectionListener = true
+            } catch (e: SecurityException) {
+                FooLog.w(TAG, "startTelephonyListenersIfPossible: unable to start data connection listener", e)
+                permissionError = true
+            }
+        }
+
+        val listenersStarted = mHasStartedCellularStateListener && mHasStartedDataConnectionListener
+        if (listenersStarted && !permissionError) {
+            updateDataConnectionInfo()
+            return true
+        }
+
+        if (permissionError) {
+            FooLog.v(TAG, "startTelephonyListenersIfPossible: still waiting for permission")
+        }
+        return false
     }
 
     private fun onTextToSpeechInitialized(status: Int, timeElapsedMillis: Long) {
@@ -795,6 +1028,10 @@ class AlfredManager(applicationContext: Context) {
     // Data Connection…
     //
     private fun updateDataConnectionInfo() {
+        if (!mHasStartedDataConnectionListener) {
+            FooLog.v(TAG, "updateDataConnectionInfo: data connection listener not started")
+            return
+        }
         val dataConnectionInfo = mDataConnectionListener.dataConnectionInfo
         if (dataConnectionInfo.isConnected) {
             onDataConnected(dataConnectionInfo)

--- a/app/src/main/java/com/swooby/alfred/MainActivity.kt
+++ b/app/src/main/java/com/swooby/alfred/MainActivity.kt
@@ -1,9 +1,12 @@
 package com.swooby.alfred
 
+import android.Manifest
 import android.app.Activity
 import android.content.Intent
+import android.content.pm.PackageManager
 import android.content.res.Configuration
 import android.media.AudioManager
+import android.os.Build
 import android.os.Bundle
 import android.speech.tts.TextToSpeech
 import android.speech.tts.Voice
@@ -17,6 +20,7 @@ import android.widget.SeekBar
 import android.widget.SeekBar.OnSeekBarChangeListener
 import androidx.appcompat.app.ActionBarDrawerToggle
 import androidx.appcompat.app.AppCompatActivity
+import androidx.core.app.ActivityCompat
 import androidx.core.view.GravityCompat
 import androidx.drawerlayout.widget.DrawerLayout
 import androidx.fragment.app.DialogFragment
@@ -48,6 +52,9 @@ class MainActivity
         private val TAG: String = FooLog.TAG(MainActivity::class.java)
 
         private const val REQUEST_ACTION_CHECK_TTS_DATA = 100
+        private const val REQUEST_PERMISSION_POST_NOTIFICATIONS = 101
+        private const val REQUEST_PERMISSION_READ_PHONE_STATE = 102
+        private const val REQUEST_PERMISSION_BLUETOOTH_CONNECT = 103
 
         private const val FRAGMENT_DIALOG_NOTIFICATION_ACCESS_DISABLED =
             "FRAGMENT_DIALOG_NOTIFICATION_ACCESS_DISABLED"
@@ -56,6 +63,30 @@ class MainActivity
     private val mAlfredManagerCallbacks: AlfredManagerCallbacks = object : AlfredManagerCallbacks {
         override val activity: Activity
             get() = this@MainActivity
+
+        override fun onReadPhoneStatePermissionRequired() {
+            this@MainActivity.onReadPhoneStatePermissionRequired()
+        }
+
+        override fun onReadPhoneStatePermissionGranted() {
+            this@MainActivity.onReadPhoneStatePermissionGranted()
+        }
+
+        override fun onBluetoothConnectPermissionRequired() {
+            this@MainActivity.onBluetoothConnectPermissionRequired()
+        }
+
+        override fun onBluetoothConnectPermissionGranted() {
+            this@MainActivity.onBluetoothConnectPermissionGranted()
+        }
+
+        override fun onPostNotificationsPermissionRequired() {
+            this@MainActivity.onPostNotificationsPermissionRequired()
+        }
+
+        override fun onPostNotificationsPermissionGranted() {
+            this@MainActivity.onPostNotificationsPermissionGranted()
+        }
 
         override fun onNotificationListenerConnected() {
             this@MainActivity.onNotificationListenerConnected()
@@ -115,6 +146,9 @@ class MainActivity
     private lateinit var mButtonProcessNotifications: Button
 
     private var mRequestedTextToSpeechData = false
+    private var mHasRequestedPostNotificationsPermission = false
+    private var mHasRequestedReadPhoneStatePermission = false
+    private var mHasRequestedBluetoothConnectPermission = false
 
     private val isDebugEnabled: Boolean
         get() = mDebugConfiguration.isDebugEnabled
@@ -483,6 +517,10 @@ class MainActivity
         mAlfredManager.attach(mAlfredManagerCallbacks)
         mTextToSpeechManager.attach(mTextToSpeechManagerCallbacks)
 
+        handleBluetoothConnectPermissionState()
+        handleReadPhoneStatePermissionState()
+        handlePostNotificationsPermissionState()
+
         if (mNotificationParserManager.isNotificationAccessSettingConfirmedEnabled) {
             if (mNotificationParserManager.isNotificationListenerConnected) {
                 onNotificationListenerConnected()
@@ -499,8 +537,205 @@ class MainActivity
         FooLog.v(TAG, "-onResume()")
     }
 
+    override fun onRequestPermissionsResult(
+        requestCode: Int,
+        permissions: Array<out String>,
+        grantResults: IntArray
+    ) {
+        super.onRequestPermissionsResult(requestCode, permissions, grantResults)
+
+        when (requestCode) {
+            REQUEST_PERMISSION_POST_NOTIFICATIONS -> {
+                val isGranted = grantResults.isNotEmpty() &&
+                        grantResults[0] == PackageManager.PERMISSION_GRANTED
+                if (isGranted) {
+                    mAlfredManager.onPostNotificationsPermissionGranted()
+                    onPostNotificationsPermissionGranted()
+                } else {
+                    onPostNotificationsPermissionDenied()
+                }
+            }
+            REQUEST_PERMISSION_READ_PHONE_STATE -> {
+                val isGranted = grantResults.isNotEmpty() &&
+                        grantResults[0] == PackageManager.PERMISSION_GRANTED
+                if (isGranted) {
+                    mAlfredManager.onReadPhoneStatePermissionGranted()
+                    onReadPhoneStatePermissionGranted()
+                } else {
+                    onReadPhoneStatePermissionDenied()
+                }
+            }
+            REQUEST_PERMISSION_BLUETOOTH_CONNECT -> {
+                val isGranted = grantResults.isNotEmpty() &&
+                        grantResults[0] == PackageManager.PERMISSION_GRANTED
+                if (isGranted) {
+                    mAlfredManager.onBluetoothConnectPermissionGranted()
+                    onBluetoothConnectPermissionGranted()
+                } else {
+                    onBluetoothConnectPermissionDenied()
+                }
+            }
+        }
+    }
+
     private fun textToSpeechTest() {
         mAlfredManager.speak(true, "Testing testing 1 2 3")
+    }
+
+    private fun handlePostNotificationsPermissionState() {
+        if (!isPostNotificationsPermissionRuntimeRequired()) {
+            return
+        }
+
+        if (mAlfredManager.hasPostNotificationsPermission) {
+            mAlfredManager.onPostNotificationsPermissionGranted()
+            onPostNotificationsPermissionGranted()
+        }
+    }
+
+    private fun handleBluetoothConnectPermissionState() {
+        if (!isBluetoothConnectPermissionRuntimeRequired()) {
+            return
+        }
+
+        if (mAlfredManager.hasBluetoothConnectPermission) {
+            mAlfredManager.onBluetoothConnectPermissionGranted()
+            onBluetoothConnectPermissionGranted()
+        }
+    }
+
+    private fun handleReadPhoneStatePermissionState() {
+        if (!isReadPhoneStatePermissionRuntimeRequired()) {
+            return
+        }
+
+        if (mAlfredManager.hasReadPhoneStatePermission) {
+            mAlfredManager.onReadPhoneStatePermissionGranted()
+            onReadPhoneStatePermissionGranted()
+        }
+    }
+
+    private fun onPostNotificationsPermissionRequired() {
+        val forceRequest = !mHasRequestedPostNotificationsPermission
+        requestPostNotificationsPermissionIfNeeded(force = forceRequest)
+    }
+
+    private fun onPostNotificationsPermissionGranted() {
+        FooLog.i(TAG, "onPostNotificationsPermissionGranted()")
+        mHasRequestedPostNotificationsPermission = false
+    }
+
+    private fun onPostNotificationsPermissionDenied() {
+        FooLog.w(TAG, "onPostNotificationsPermissionDenied()")
+        mHasRequestedPostNotificationsPermission = true
+    }
+
+    private fun onReadPhoneStatePermissionRequired() {
+        val forceRequest = !mHasRequestedReadPhoneStatePermission
+        requestReadPhoneStatePermissionIfNeeded(force = forceRequest)
+    }
+
+    private fun onReadPhoneStatePermissionGranted() {
+        FooLog.i(TAG, "onReadPhoneStatePermissionGranted()")
+        mHasRequestedReadPhoneStatePermission = false
+    }
+
+    private fun onReadPhoneStatePermissionDenied() {
+        FooLog.w(TAG, "onReadPhoneStatePermissionDenied()")
+        mHasRequestedReadPhoneStatePermission = true
+    }
+
+    private fun onBluetoothConnectPermissionRequired() {
+        val forceRequest = !mHasRequestedBluetoothConnectPermission
+        requestBluetoothConnectPermissionIfNeeded(force = forceRequest)
+    }
+
+    private fun onBluetoothConnectPermissionGranted() {
+        FooLog.i(TAG, "onBluetoothConnectPermissionGranted()")
+        mHasRequestedBluetoothConnectPermission = false
+    }
+
+    private fun onBluetoothConnectPermissionDenied() {
+        FooLog.w(TAG, "onBluetoothConnectPermissionDenied()")
+        mHasRequestedBluetoothConnectPermission = true
+    }
+
+    private fun requestPostNotificationsPermissionIfNeeded(force: Boolean = false) {
+        if (!isPostNotificationsPermissionRuntimeRequired()) {
+            return
+        }
+
+        if (mAlfredManager.hasPostNotificationsPermission) {
+            return
+        }
+
+        if (!force && mHasRequestedPostNotificationsPermission) {
+            return
+        }
+
+        FooLog.i(TAG, "requestPostNotificationsPermissionIfNeeded: requesting")
+        ActivityCompat.requestPermissions(
+            this,
+            arrayOf(Manifest.permission.POST_NOTIFICATIONS),
+            REQUEST_PERMISSION_POST_NOTIFICATIONS
+        )
+        mHasRequestedPostNotificationsPermission = true
+    }
+
+    private fun requestReadPhoneStatePermissionIfNeeded(force: Boolean = false) {
+        if (!isReadPhoneStatePermissionRuntimeRequired()) {
+            return
+        }
+
+        if (mAlfredManager.hasReadPhoneStatePermission) {
+            return
+        }
+
+        if (!force && mHasRequestedReadPhoneStatePermission) {
+            return
+        }
+
+        FooLog.i(TAG, "requestReadPhoneStatePermissionIfNeeded: requesting")
+        ActivityCompat.requestPermissions(
+            this,
+            arrayOf(Manifest.permission.READ_PHONE_STATE),
+            REQUEST_PERMISSION_READ_PHONE_STATE
+        )
+        mHasRequestedReadPhoneStatePermission = true
+    }
+
+    private fun requestBluetoothConnectPermissionIfNeeded(force: Boolean = false) {
+        if (!isBluetoothConnectPermissionRuntimeRequired()) {
+            return
+        }
+
+        if (mAlfredManager.hasBluetoothConnectPermission) {
+            return
+        }
+
+        if (!force && mHasRequestedBluetoothConnectPermission) {
+            return
+        }
+
+        FooLog.i(TAG, "requestBluetoothConnectPermissionIfNeeded: requesting")
+        ActivityCompat.requestPermissions(
+            this,
+            arrayOf(Manifest.permission.BLUETOOTH_CONNECT),
+            REQUEST_PERMISSION_BLUETOOTH_CONNECT
+        )
+        mHasRequestedBluetoothConnectPermission = true
+    }
+
+    private fun isPostNotificationsPermissionRuntimeRequired(): Boolean {
+        return Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU
+    }
+
+    private fun isBluetoothConnectPermissionRuntimeRequired(): Boolean {
+        return Build.VERSION.SDK_INT >= Build.VERSION_CODES.S
+    }
+
+    private fun isReadPhoneStatePermissionRuntimeRequired(): Boolean {
+        return Build.VERSION.SDK_INT >= Build.VERSION_CODES.M
     }
 
     private fun textToSpeechVoiceUpdate() {

--- a/app/src/main/java/com/swooby/alfred/MandatoryPermissions.kt
+++ b/app/src/main/java/com/swooby/alfred/MandatoryPermissions.kt
@@ -1,0 +1,107 @@
+package com.swooby.alfred
+
+import android.content.Context
+import com.smartfoo.android.core.logging.FooLog
+import com.smartfoo.android.core.permissions.FooPermissionsChecker
+import java.util.LinkedHashMap
+import java.util.LinkedHashSet
+
+/**
+ * Tracks permission-gated initialisation routines that must succeed before Alfred can operate.
+ *
+ * Each mandatory permission is registered with a lambda that returns `true` when the
+ * permission-dependent initialisation has completed. When a permission is missing the registered
+ * listener is notified once. When the permission is granted (and the initialisation succeeds) a
+ * matching "granted" callback is emitted so UI components can react accordingly.
+ */
+class MandatoryPermissions(
+    private val context: Context,
+    private val listener: Listener
+) {
+
+    interface Listener {
+        fun onMandatoryPermissionRequired(permission: String)
+        fun onMandatoryPermissionGranted(permission: String)
+    }
+
+    private data class Entry(
+        val permission: String,
+        val initializer: () -> Boolean,
+        var isInitialized: Boolean = false,
+        var hasNotifiedRequired: Boolean = false
+    )
+
+    private val entries = LinkedHashMap<String, Entry>()
+
+    fun register(permission: String, initializer: () -> Boolean) {
+        val existing = entries[permission]
+        if (existing != null) {
+            FooLog.w(TAG, "register: permission=" + permission + " already registered")
+            return
+        }
+        entries[permission] = Entry(permission, initializer)
+    }
+
+    fun evaluate() {
+        for (entry in entries.values) {
+            updateEntry(entry)
+        }
+    }
+
+    fun onPermissionGranted(permission: String) {
+        val entry = entries[permission]
+        if (entry != null) {
+            updateEntry(entry)
+        }
+    }
+
+    fun isPermissionMissing(permission: String): Boolean {
+        val entry = entries[permission] ?: return false
+        return !entry.isInitialized
+    }
+
+    fun missingPermissions(): Set<String> {
+        val missing = LinkedHashSet<String>()
+        for (entry in entries.values) {
+            if (!entry.isInitialized) {
+                missing += entry.permission
+            }
+        }
+        return missing
+    }
+
+    private fun updateEntry(entry: Entry) {
+        val isGranted = FooPermissionsChecker.isPermissionGranted(context, entry.permission)
+        if (!isGranted) {
+            if (!entry.hasNotifiedRequired) {
+                listener.onMandatoryPermissionRequired(entry.permission)
+                entry.hasNotifiedRequired = true
+            }
+            entry.isInitialized = false
+            return
+        }
+
+        val wasInitialized = entry.isInitialized
+        val initialised = try {
+            entry.initializer()
+        } catch (e: SecurityException) {
+            FooLog.w(TAG, "initializer threw SecurityException for permission=" + entry.permission, e)
+            false
+        }
+
+        entry.isInitialized = initialised
+        if (initialised) {
+            if (entry.hasNotifiedRequired) {
+                listener.onMandatoryPermissionGranted(entry.permission)
+            }
+            entry.hasNotifiedRequired = false
+        } else if (!entry.hasNotifiedRequired || wasInitialized) {
+            listener.onMandatoryPermissionRequired(entry.permission)
+            entry.hasNotifiedRequired = true
+        }
+    }
+
+    companion object {
+        private val TAG = FooLog.TAG(MandatoryPermissions::class.java)
+    }
+}


### PR DESCRIPTION
## Summary
- gate ProfileManager start/attach behind the BLUETOOTH_CONNECT mandatory permission so Alfred defers profile wiring until access is granted
- surface the bluetooth permission requirement through AlfredManager callbacks and MainActivity so the UI can request and resume initialization once granted

## Testing
- ./gradlew :app:lint *(fails: Unable to tunnel through proxy. Proxy returns "HTTP/1.1 403 Forbidden")*

------
https://chatgpt.com/codex/tasks/task_e_68d5f340fc008333b68fda5a724d5bf3