### PR TITLE
Replace deprecated back press override

### DIFF
--- a/app/src/main/java/com/swooby/alfred/MainActivity.kt
+++ b/app/src/main/java/com/swooby/alfred/MainActivity.kt
@@ -19,6 +19,7 @@ import android.widget.ArrayAdapter
 import android.widget.Button
 import android.widget.SeekBar
 import android.widget.SeekBar.OnSeekBarChangeListener
+import androidx.activity.OnBackPressedCallback
 import androidx.appcompat.app.ActionBarDrawerToggle
 import androidx.appcompat.app.AppCompatActivity
 import androidx.core.app.ActivityCompat
@@ -181,6 +182,20 @@ class MainActivity
         }
         mDrawerToggle.isDrawerIndicatorEnabled = true
         mDrawerLayout.addDrawerListener(mDrawerToggle)
+        onBackPressedDispatcher.addCallback(
+            this,
+            object : OnBackPressedCallback(true) {
+                override fun handleOnBackPressed() {
+                    if (mDrawerLayout.isDrawerOpen(GravityCompat.START)) {
+                        mDrawerLayout.closeDrawer(GravityCompat.START)
+                    } else {
+                        isEnabled = false
+                        onBackPressedDispatcher.onBackPressed()
+                        isEnabled = true
+                    }
+                }
+            }
+        )
         mDrawerToggle.syncState()
 
         mNavigationView = binding.navView
@@ -359,14 +374,6 @@ class MainActivity
     override fun onConfigurationChanged(newConfig: Configuration) {
         super.onConfigurationChanged(newConfig)
         mDrawerToggle.onConfigurationChanged(newConfig)
-    }
-
-    override fun onBackPressed() {
-        if (mDrawerLayout.isDrawerOpen(GravityCompat.START)) {
-            mDrawerLayout.closeDrawer(GravityCompat.START)
-        } else {
-            super.onBackPressed()
-        }
     }
 
     /*


### PR DESCRIPTION
## Summary
- register an OnBackPressedCallback to handle drawer closure and fall back to default behavior
- remove the deprecated onBackPressed override now that handling is delegated to the dispatcher

## Testing
- Not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d6d5e52ee48333a8a567ee06b190bf