### PR TITLE
Ensure Alfred foreground notification stays ongoing

### DIFF
--- a/app/src/main/java/com/swooby/alfred/NotificationManager.java
+++ b/app/src/main/java/com/swooby/alfred/NotificationManager.java
@@ -12,6 +12,8 @@ import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import androidx.annotation.RequiresPermission;
 
+import androidx.core.app.NotificationCompat;
+
 import com.smartfoo.android.core.FooRun;
 import com.smartfoo.android.core.FooString;
 import com.smartfoo.android.core.collections.FooBundleBuilder;
@@ -266,7 +268,10 @@ public class NotificationManager
 
         if (foregroundServiceType != FooNotification.FOREGROUND_SERVICE_TYPE_NONE)
         {
-            builder.setOngoing(true);
+            builder.setOngoing(true)
+                    .setAutoCancel(false)
+                    .setOnlyAlertOnce(true)
+                    .setCategory(NotificationCompat.CATEGORY_SERVICE);
         }
 
         PendingIntent pendingIntent = status.getPendingIntent();


### PR DESCRIPTION
## Summary
- mark the Alfred foreground notification as a service notification
- ensure the notification stays ongoing, non-dismissible, and alerts only once when updated

## Testing
- ./gradlew assembleDebug *(fails: Unable to tunnel through proxy. Proxy returns "HTTP/1.1 403 Forbidden")*

------
https://chatgpt.com/codex/tasks/task_e_68d6eb63abfc8333a6c5cd2d26a49665