### PR TITLE
Make Alfred foreground notification persistent with quit action

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,7 @@ environment might find this app useful.
 * Better Facebook messenger parsing
 * How to detect phone boot and launch app without requiring screen unlock?
 * Screen unlock/lock listener
+* Screen dim/un-dim listener
 * Button to test adding two notifications and reading them serially but cancelable
 * Button to test repetitive notifications
 * "Share to Alfred" could read whatever is being shared

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -80,6 +80,11 @@
         </service>
 
         <receiver
+            android:name=".NotificationActionReceiver"
+            android:enabled="true"
+            android:exported="false" />
+
+        <receiver
             android:name="com.smartfoo.android.core.platform.FooBootListener$FooLockedBootCompletedBroadcastReceiver"
             android:directBootAware="true"
             android:exported="true"

--- a/app/src/main/java/com/swooby/alfred/ActivityLifecyclesObserver.kt
+++ b/app/src/main/java/com/swooby/alfred/ActivityLifecyclesObserver.kt
@@ -26,12 +26,29 @@ class ActivityLifecyclesObserver(private val application: Application)  {
     val isBackground: Boolean
         get() = !isForeground
 
+    private var isRegistered = false
+
     fun start() {
+        if (isRegistered) {
+            return
+        }
         application.registerActivityLifecycleCallbacks(activityLifecycleCallbacks)
+        isRegistered = true
     }
 
     fun stop() {
+        if (!isRegistered) {
+            return
+        }
         application.unregisterActivityLifecycleCallbacks(activityLifecycleCallbacks)
+        isRegistered = false
+    }
+
+    fun finishStartedActivities() {
+        val activities = startedActivities.toList()
+        for (activity in activities) {
+            activity.finish()
+        }
     }
 
     private val startedActivities = mutableSetOf<Activity>()

--- a/app/src/main/java/com/swooby/alfred/AlfredManager.kt
+++ b/app/src/main/java/com/swooby/alfred/AlfredManager.kt
@@ -360,10 +360,27 @@ class AlfredManager(applicationContext: Context) {
     }
 
     fun stop() {
+        if (!isStarted) {
+            FooLog.i(TAG, "stop(): already stopped")
+            return
+        }
         FooLog.i(TAG, "+stop()")
         isStarted = false
         mActivityLifecyclesObserver.stop()
         FooLog.i(TAG, "-stop()")
+    }
+
+    fun quit() {
+        FooLog.i(TAG, "+quit()")
+        mNotificationManager.cancelOngoingNotification()
+        mActivityLifecyclesObserver.finishStartedActivities()
+        textToSpeechManager.clear()
+        if (isStarted) {
+            stop()
+        } else {
+            mActivityLifecyclesObserver.stop()
+        }
+        FooLog.i(TAG, "-quit()")
     }
 
     /*

--- a/app/src/main/java/com/swooby/alfred/AlfredManager.kt
+++ b/app/src/main/java/com/swooby/alfred/AlfredManager.kt
@@ -360,19 +360,24 @@ class AlfredManager(applicationContext: Context) {
     }
 
     fun stop() {
-        if (!isStarted) {
-            FooLog.i(TAG, "stop(): already stopped")
-            return
-        }
         FooLog.i(TAG, "+stop()")
-        isStarted = false
-        mActivityLifecyclesObserver.stop()
+        if (isStarted) {
+            isStarted = false
+            //...
+            mActivityLifecyclesObserver.stop()
+            //...
+        } else {
+            FooLog.i(TAG, "stop(): already stopped")
+        }
         FooLog.i(TAG, "-stop()")
     }
 
     fun quit() {
         FooLog.i(TAG, "+quit()")
-        mNotificationManager.cancelOngoingNotification()
+        if (isPermissionGranted(Manifest.permission.POST_NOTIFICATIONS)) {
+            //noinspection MissingPermission
+            mNotificationManager.cancelOngoingNotification()
+        }
         mActivityLifecyclesObserver.finishStartedActivities()
         textToSpeechManager.clear()
         if (isStarted) {

--- a/app/src/main/java/com/swooby/alfred/MainActivity.kt
+++ b/app/src/main/java/com/swooby/alfred/MainActivity.kt
@@ -1,12 +1,10 @@
 package com.swooby.alfred
 
-import android.Manifest
 import android.app.Activity
 import android.content.Intent
 import android.content.pm.PackageManager
 import android.content.res.Configuration
 import android.media.AudioManager
-import android.os.Build
 import android.os.Bundle
 import android.os.PersistableBundle
 import android.speech.tts.TextToSpeech

--- a/app/src/main/java/com/swooby/alfred/NotificationActionReceiver.kt
+++ b/app/src/main/java/com/swooby/alfred/NotificationActionReceiver.kt
@@ -1,0 +1,34 @@
+package com.swooby.alfred
+
+import android.content.BroadcastReceiver
+import android.content.Context
+import android.content.Intent
+import com.smartfoo.android.core.logging.FooLog
+import com.smartfoo.android.core.platform.FooPlatformUtils
+
+class NotificationActionReceiver : BroadcastReceiver() {
+
+    override fun onReceive(context: Context, intent: Intent?) {
+        FooLog.i(TAG, "+onReceive(context, intent=" + FooPlatformUtils.toString(intent) + ')')
+        if (intent?.action == ACTION_QUIT) {
+            val application = MainApplication.getMainApplication(context)
+            application.alfredManager.quit()
+        } else {
+            FooLog.w(TAG, "onReceive: Unexpected action=" + intent?.action)
+        }
+        FooLog.i(TAG, "-onReceive(context, intent=" + FooPlatformUtils.toString(intent) + ')')
+    }
+
+    companion object {
+        private val TAG: String = FooLog.TAG(NotificationActionReceiver::class.java)
+
+        @JvmField
+        val ACTION_QUIT: String = NotificationActionReceiver::class.java.name + ".ACTION_QUIT"
+
+        @JvmStatic
+        fun createQuitIntent(context: Context): Intent {
+            return Intent(context, NotificationActionReceiver::class.java).setAction(ACTION_QUIT)
+        }
+    }
+}
+

--- a/app/src/main/java/com/swooby/alfred/NotificationManager.java
+++ b/app/src/main/java/com/swooby/alfred/NotificationManager.java
@@ -24,6 +24,7 @@ import com.smartfoo.android.core.notification.FooNotification.Companion.ChannelI
 import com.smartfoo.android.core.notification.FooNotificationBuilder;
 import com.smartfoo.android.core.notification.FooNotificationListenerManager;
 import com.smartfoo.android.core.platform.FooRes;
+import com.swooby.alfred.NotificationActionReceiver;
 import com.swooby.alfred.Profile.Tokens;
 
 public class NotificationManager
@@ -224,6 +225,7 @@ public class NotificationManager
     private interface NotificationIds
     {
         int ONGOING = 100;
+        int ACTION_QUIT = 101;
     }
 
     private final Context mContext;
@@ -272,12 +274,24 @@ public class NotificationManager
 
         FooNotificationBuilder builder = new FooNotificationBuilder(mContext, CHANNEL_INFO.id);
 
-        if (foregroundServiceType != FooNotification.FOREGROUND_SERVICE_TYPE_NONE)
+        boolean isOngoingNotification = requestCode == NotificationIds.ONGOING;
+
+        if (foregroundServiceType != FooNotification.FOREGROUND_SERVICE_TYPE_NONE || isOngoingNotification)
         {
             builder.setOngoing(true)
                     .setAutoCancel(false)
                     .setOnlyAlertOnce(true)
                     .setCategory(NotificationCompat.CATEGORY_SERVICE);
+        }
+
+        if (isOngoingNotification)
+        {
+            builder.addActionBroadcast(
+                    R.drawable.ic_warning,
+                    R.string.alfred_notification_action_quit,
+                    NotificationIds.ACTION_QUIT,
+                    NotificationActionReceiver.createQuitIntent(mContext),
+                    PendingIntent.FLAG_UPDATE_CURRENT | PendingIntent.FLAG_IMMUTABLE);
         }
 
         PendingIntent pendingIntent = status.getPendingIntent();
@@ -308,6 +322,12 @@ public class NotificationManager
     private void notificationOngoingShow(@NonNull NotificationStatus notificationStatus, @NonNull String contentTitle, @Nullable String contentText)
     {
         mNotificationOngoing = notificationShow(NotificationIds.ONGOING, FOREGROUND_SERVICE_TYPE, notificationStatus, contentTitle, contentText);
+    }
+
+    @RequiresPermission(Manifest.permission.POST_NOTIFICATIONS)
+    void cancelOngoingNotification()
+    {
+        notificationOngoingCancel();
     }
 
     private void notificationOngoingCancel()

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -22,6 +22,7 @@
     <string name="action_text_to_speech">Text-To-Speech</string>
     <string name="action_debug_show_debug_log">Show Debug Log</string>
     <string name="action_debug_clear_debug_log">Clear Debug Log</string>
+    <string name="alfred_notification_action_quit">Quit</string>
     <!--
     <string name="action_debug_disable_debug_mode">Disable Debug Mode</string>
     -->


### PR DESCRIPTION
## Summary
- keep the Alfred foreground notification flagged as ongoing and add a Quit action button
- handle the Quit action by clearing AlfredManager state, finishing activities, and stopping the notification service
- guard activity lifecycle callback registration to avoid duplicate unregister calls

## Testing
- ⚠️ `./gradlew assembleDebug` *(fails: Unable to tunnel through proxy. Proxy returns "HTTP/1.1 403 Forbidden")*


------
https://chatgpt.com/codex/tasks/task_e_68d6ef23f1d883338663e136259be9f6