### PR TITLE
Add persistent notification action to Alfred ongoing notification

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -43,6 +43,15 @@
         </activity>
 
         <activity
+            android:name=".PersistentNotificationDialogActivity"
+            android:exported="false"
+            android:excludeFromRecents="true"
+            android:finishOnTaskLaunch="true"
+            android:launchMode="singleTop"
+            android:theme="@style/Theme.Alfred.Dialog"
+            />
+
+        <activity
             android:name="com.smartfoo.android.core.app.FooDebugActivity"
             android:label="@string/activity_debug_title"
             android:parentActivityName=".MainActivity"

--- a/app/src/main/java/com/swooby/alfred/AlfredManager.kt
+++ b/app/src/main/java/com/swooby/alfred/AlfredManager.kt
@@ -455,6 +455,28 @@ class AlfredManager(applicationContext: Context) {
         }
     }
 
+    fun refreshOngoingNotification() {
+        val notificationStatus: NotificationStatus = when {
+            !isProfileEnabled -> {
+                val profile = profileManager.profile
+                NotificationStatusProfileNotEnabled(applicationContext, profile)
+            }
+            !notificationParserManager.isNotificationListenerConnected -> {
+                NotificationStatusNotificationAccessNotEnabled(
+                    applicationContext,
+                    getString(R.string.alfred_running),
+                    getString(R.string.alfred_waiting_for_notification_access),
+                    null,
+                )
+            }
+            else -> {
+                NotificationStatusRunning(applicationContext)
+            }
+        }
+
+        notification(notificationStatus, "TBD text", "refreshOngoingNotification")
+    }
+
     fun onActivityPermissionGranted(permission: String): Boolean {
         FooLog.i(TAG, "onActivityPermissionGranted(permission=${FooString.quote(permission)})")
         return checkRequiredPermissions()

--- a/app/src/main/java/com/swooby/alfred/AppPreferences.kt
+++ b/app/src/main/java/com/swooby/alfred/AppPreferences.kt
@@ -18,6 +18,8 @@ class AppPreferences(applicationContext: Context?)
         private const val KEY_USER_VOICE_AUDIO_STREAM_TYPE = "pref_user_tts_voice_audio_stream_type"
         private const val KEY_USER_PROFILE_TOKEN = "pref_user_profile_token"
         private const val KEY_USER_KEYPHRASE = "pref_user_keyphrase"
+        private const val KEY_USER_PERSISTENT_NOTIFICATION_ACTION_IGNORED =
+            "pref_user_persistent_notification_action_ignored"
     }
 
     init {
@@ -88,6 +90,21 @@ class AppPreferences(applicationContext: Context?)
         setString(
             FILE_NAME_USER,
             KEY_USER_KEYPHRASE,
+            value
+        )
+    }
+
+    fun isPersistentNotificationActionIgnored(): Boolean {
+        return getBoolean(
+            FILE_NAME_USER,
+            KEY_USER_PERSISTENT_NOTIFICATION_ACTION_IGNORED,
+            false
+        )
+    }
+    fun setPersistentNotificationActionIgnored(value: Boolean) {
+        setBoolean(
+            FILE_NAME_USER,
+            KEY_USER_PERSISTENT_NOTIFICATION_ACTION_IGNORED,
             value
         )
     }

--- a/app/src/main/java/com/swooby/alfred/MainActivity.kt
+++ b/app/src/main/java/com/swooby/alfred/MainActivity.kt
@@ -108,6 +108,7 @@ class MainActivity
     private lateinit var mTextToSpeechManager: TextToSpeechManager
     private lateinit var mProfileManager: ProfileManager
     private lateinit var mNotificationParserManager: NotificationParserManager
+    private lateinit var mAppPreferences: AppPreferences
 
     private lateinit var mAudioManager: AudioManager
     private lateinit var mAudioStreamVolumeObserver: FooAudioStreamVolumeObserver
@@ -142,6 +143,7 @@ class MainActivity
         mTextToSpeechManager = mAlfredManager.textToSpeechManager
         mProfileManager = mAlfredManager.profileManager
         mNotificationParserManager = mAlfredManager.notificationParserManager
+        mAppPreferences = AppPreferences(applicationContext)
 
         mAudioManager = getSystemService(AUDIO_SERVICE) as AudioManager
 
@@ -406,6 +408,9 @@ class MainActivity
         menuItem = menu.findItem(R.id.action_debug_clear_debug_log)
         menuItem?.setVisible(isLoggingEnabled)
 
+        menuItem = menu.findItem(R.id.action_show_persistent_notification_help)
+        menuItem?.setVisible(mAppPreferences.isPersistentNotificationActionIgnored())
+
         //…
         return super.onPrepareOptionsMenu(menu)
     }
@@ -461,6 +466,10 @@ class MainActivity
             }
             R.id.action_debug_clear_debug_log -> {
                 FooLog.clear()
+                return true
+            }
+            R.id.action_show_persistent_notification_help -> {
+                showPersistentNotificationHelp()
                 return true
             }
         }
@@ -527,7 +536,13 @@ class MainActivity
 
         profilesUpdate()
 
+        invalidateOptionsMenu()
+
         FooLog.v(TAG, "-onResume()")
+    }
+
+    private fun showPersistentNotificationHelp() {
+        startActivity(PersistentNotificationDialogActivity.createIntent(this))
     }
 
     override fun onRequestPermissionsResult(

--- a/app/src/main/java/com/swooby/alfred/NotificationManager.java
+++ b/app/src/main/java/com/swooby/alfred/NotificationManager.java
@@ -6,15 +6,12 @@ import android.app.PendingIntent;
 import android.content.Context;
 import android.content.Intent;
 import android.content.pm.ServiceInfo;
-import android.os.Build;
 import android.os.Bundle;
-import android.service.notification.StatusBarNotification;
 
 import androidx.annotation.DrawableRes;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import androidx.annotation.RequiresPermission;
-
 import androidx.core.app.NotificationCompat;
 
 import com.smartfoo.android.core.FooRun;
@@ -26,8 +23,6 @@ import com.smartfoo.android.core.notification.FooNotification.Companion.ChannelI
 import com.smartfoo.android.core.notification.FooNotificationBuilder;
 import com.smartfoo.android.core.notification.FooNotificationListenerManager;
 import com.smartfoo.android.core.platform.FooRes;
-import com.swooby.alfred.NotificationActionReceiver;
-import com.swooby.alfred.PersistentNotificationDialogActivity;
 import com.swooby.alfred.Profile.Tokens;
 
 public class NotificationManager
@@ -233,6 +228,7 @@ public class NotificationManager
     }
 
     private final Context mContext;
+    private final AppPreferences mAppPreferences;
 
     private FooNotification mNotificationOngoing;
 
@@ -240,28 +236,13 @@ public class NotificationManager
     {
         FooRun.throwIllegalArgumentExceptionIfNull(context, "context");
         mContext = context;
+        mAppPreferences = new AppPreferences(context.getApplicationContext());
         FooNotification.createNotificationChannel(mContext, CHANNEL_INFO);
     }
 
     private String getString(int resId, Object... formatArgs)
     {
         return mContext.getString(resId, formatArgs);
-    }
-
-    @RequiresPermission(Manifest.permission.POST_NOTIFICATIONS)
-    private FooNotification notificationShow(int requestCode,
-                                             int foregroundServiceType,
-                                             @NonNull FooNotificationBuilder builder)
-    {
-        FooNotification notification = new FooNotification(requestCode, foregroundServiceType, builder);
-        FooLog.v(TAG, "notificationShow: notification=" + notification);
-        if (requestCode == NotificationIds.ONGOING)
-        {
-            Notification androidNotification = notification.getNotification();
-            androidNotification.flags |= Notification.FLAG_NO_CLEAR;
-        }
-        notification.show(mContext);
-        return notification;
     }
 
     /** @noinspection SameParameterValue*/
@@ -276,28 +257,44 @@ public class NotificationManager
         FooRun.throwIllegalArgumentExceptionIfNullOrEmpty(contentTitle, "contentTitle");
         //FooRun.throwIllegalArgumentExceptionIfNullOrEmpty(contentText, "contentText");
 
-        FooNotificationBuilder builder = new FooNotificationBuilder(mContext, CHANNEL_INFO.id);
+        FooNotificationBuilder builder = new FooNotificationBuilder(mContext, CHANNEL_INFO.getId());
 
-        boolean isOngoingNotification = requestCode == NotificationIds.ONGOING;
-
-        if (foregroundServiceType != FooNotification.FOREGROUND_SERVICE_TYPE_NONE || isOngoingNotification)
+        boolean isOngoingNotification = requestCode == NotificationIds.ONGOING || foregroundServiceType != FooNotification.FOREGROUND_SERVICE_TYPE_NONE;
+        if (isOngoingNotification)
         {
             builder.setOngoing(true)
                     .setAutoCancel(false)
                     .setOnlyAlertOnce(true)
                     .setCategory(NotificationCompat.CATEGORY_SERVICE);
-        }
 
-        if (isOngoingNotification)
-        {
-            if (shouldShowPersistentNotificationAction())
+            if (!mAppPreferences.isPersistentNotificationActionIgnored())
             {
-                builder.addActionActivity(
-                        R.drawable.ic_warning,
-                        R.string.alfred_notification_action_persistent,
-                        NotificationIds.ACTION_PERSISTENT,
-                        PersistentNotificationDialogActivity.createIntent(mContext),
-                        PendingIntent.FLAG_UPDATE_CURRENT | PendingIntent.FLAG_IMMUTABLE);
+                Notification existingNotification = FooNotification.findCallingAppNotification(mContext, requestCode);
+                if (!FooNotification.getNoDismiss(existingNotification))
+                {
+                    //
+                    // NOTE: Since Android 14 (API34) persistent notifications can be dismissed by the user...
+                    // ...unless...
+                    // https://www.reddit.com/r/tasker/comments/1fv9ez4/how_to_enable_nondismissible_persistent/
+                    //
+                    // To enable:
+                    // `adb shell appops set --uid com.swooby.alfred2017m2 SYSTEM_EXEMPT_FROM_DISMISSIBLE_NOTIFICATIONS allow`
+                    //
+                    // This will add a `android.app.Notification.FLAG_NO_DISMISS` to the notification that can be seen with:
+                    // `adb shell dumpsys notification --noredact | grep alfred2017m2`
+                    //
+                    // To disable:
+                    // `adb shell appops set --uid com.swooby.alfred2017m2 SYSTEM_EXEMPT_FROM_DISMISSIBLE_NOTIFICATIONS default`
+                    //
+                    // There are some other goodies in this article that might be of some help in the future.
+                    //
+                    builder.addActionActivity(
+                            R.drawable.ic_warning,
+                            R.string.alfred_notification_action_persistent,
+                            NotificationIds.ACTION_PERSISTENT,
+                            PersistentNotificationDialogActivity.createIntent(mContext),
+                            PendingIntent.FLAG_UPDATE_CURRENT | PendingIntent.FLAG_IMMUTABLE);
+                }
             }
             builder.addActionBroadcast(
                     R.drawable.ic_warning,
@@ -331,57 +328,15 @@ public class NotificationManager
         return notificationShow(requestCode, foregroundServiceType, builder);
     }
 
-    private boolean shouldShowPersistentNotificationAction()
+    @RequiresPermission(Manifest.permission.POST_NOTIFICATIONS)
+    private FooNotification notificationShow(int requestCode,
+                                             int foregroundServiceType,
+                                             @NonNull FooNotificationBuilder builder)
     {
-        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.UPSIDE_DOWN_CAKE)
-        {
-            return true;
-        }
-
-        if (mNotificationOngoing != null)
-        {
-            Notification ongoingNotification = mNotificationOngoing.getNotification();
-            if ((ongoingNotification.flags & Notification.FLAG_NO_DISMISS) == Notification.FLAG_NO_DISMISS)
-            {
-                FooLog.v(TAG, "shouldShowPersistentNotificationAction: Cached notification already has NO_DISMISS flag");
-                return false;
-            }
-        }
-
-        android.app.NotificationManager notificationManager =
-                mContext.getSystemService(android.app.NotificationManager.class);
-        if (notificationManager == null)
-        {
-            FooLog.w(TAG, "shouldShowPersistentNotificationAction: notificationManager == null");
-            return true;
-        }
-
-        try
-        {
-            StatusBarNotification[] activeNotifications = notificationManager.getActiveNotifications();
-            if (activeNotifications != null)
-            {
-                for (StatusBarNotification statusBarNotification : activeNotifications)
-                {
-                    if (statusBarNotification.getId() == NotificationIds.ONGOING)
-                    {
-                        Notification notification = statusBarNotification.getNotification();
-                        if ((notification.flags & Notification.FLAG_NO_DISMISS) == Notification.FLAG_NO_DISMISS)
-                        {
-                            FooLog.v(TAG, "shouldShowPersistentNotificationAction: Active notification already has NO_DISMISS flag");
-                            return false;
-                        }
-                        break;
-                    }
-                }
-            }
-        }
-        catch (SecurityException | RuntimeException e)
-        {
-            FooLog.w(TAG, "shouldShowPersistentNotificationAction: Unable to query active notifications", e);
-        }
-
-        return true;
+        FooNotification notification = new FooNotification(requestCode, foregroundServiceType, builder);
+        FooLog.v(TAG, "notificationShow: notification=" + notification);
+        notification.show(mContext);
+        return notification;
     }
 
     @RequiresPermission(Manifest.permission.POST_NOTIFICATIONS)

--- a/app/src/main/java/com/swooby/alfred/NotificationManager.java
+++ b/app/src/main/java/com/swooby/alfred/NotificationManager.java
@@ -6,7 +6,9 @@ import android.app.PendingIntent;
 import android.content.Context;
 import android.content.Intent;
 import android.content.pm.ServiceInfo;
+import android.os.Build;
 import android.os.Bundle;
+import android.service.notification.StatusBarNotification;
 
 import androidx.annotation.DrawableRes;
 import androidx.annotation.NonNull;
@@ -25,6 +27,7 @@ import com.smartfoo.android.core.notification.FooNotificationBuilder;
 import com.smartfoo.android.core.notification.FooNotificationListenerManager;
 import com.smartfoo.android.core.platform.FooRes;
 import com.swooby.alfred.NotificationActionReceiver;
+import com.swooby.alfred.PersistentNotificationDialogActivity;
 import com.swooby.alfred.Profile.Tokens;
 
 public class NotificationManager
@@ -226,6 +229,7 @@ public class NotificationManager
     {
         int ONGOING = 100;
         int ACTION_QUIT = 101;
+        int ACTION_PERSISTENT = 102;
     }
 
     private final Context mContext;
@@ -286,6 +290,15 @@ public class NotificationManager
 
         if (isOngoingNotification)
         {
+            if (shouldShowPersistentNotificationAction())
+            {
+                builder.addActionActivity(
+                        R.drawable.ic_warning,
+                        R.string.alfred_notification_action_persistent,
+                        NotificationIds.ACTION_PERSISTENT,
+                        PersistentNotificationDialogActivity.createIntent(mContext),
+                        PendingIntent.FLAG_UPDATE_CURRENT | PendingIntent.FLAG_IMMUTABLE);
+            }
             builder.addActionBroadcast(
                     R.drawable.ic_warning,
                     R.string.alfred_notification_action_quit,
@@ -316,6 +329,59 @@ public class NotificationManager
         }
 
         return notificationShow(requestCode, foregroundServiceType, builder);
+    }
+
+    private boolean shouldShowPersistentNotificationAction()
+    {
+        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.UPSIDE_DOWN_CAKE)
+        {
+            return true;
+        }
+
+        if (mNotificationOngoing != null)
+        {
+            Notification ongoingNotification = mNotificationOngoing.getNotification();
+            if ((ongoingNotification.flags & Notification.FLAG_NO_DISMISS) == Notification.FLAG_NO_DISMISS)
+            {
+                FooLog.v(TAG, "shouldShowPersistentNotificationAction: Cached notification already has NO_DISMISS flag");
+                return false;
+            }
+        }
+
+        android.app.NotificationManager notificationManager =
+                mContext.getSystemService(android.app.NotificationManager.class);
+        if (notificationManager == null)
+        {
+            FooLog.w(TAG, "shouldShowPersistentNotificationAction: notificationManager == null");
+            return true;
+        }
+
+        try
+        {
+            StatusBarNotification[] activeNotifications = notificationManager.getActiveNotifications();
+            if (activeNotifications != null)
+            {
+                for (StatusBarNotification statusBarNotification : activeNotifications)
+                {
+                    if (statusBarNotification.getId() == NotificationIds.ONGOING)
+                    {
+                        Notification notification = statusBarNotification.getNotification();
+                        if ((notification.flags & Notification.FLAG_NO_DISMISS) == Notification.FLAG_NO_DISMISS)
+                        {
+                            FooLog.v(TAG, "shouldShowPersistentNotificationAction: Active notification already has NO_DISMISS flag");
+                            return false;
+                        }
+                        break;
+                    }
+                }
+            }
+        }
+        catch (SecurityException | RuntimeException e)
+        {
+            FooLog.w(TAG, "shouldShowPersistentNotificationAction: Unable to query active notifications", e);
+        }
+
+        return true;
     }
 
     @RequiresPermission(Manifest.permission.POST_NOTIFICATIONS)

--- a/app/src/main/java/com/swooby/alfred/PersistentNotificationDialogActivity.kt
+++ b/app/src/main/java/com/swooby/alfred/PersistentNotificationDialogActivity.kt
@@ -1,16 +1,31 @@
 package com.swooby.alfred
 
+import android.content.ClipData
+import android.content.ClipboardManager
 import android.content.Context
 import android.content.Intent
+import android.graphics.Typeface
 import android.os.Bundle
+import android.widget.Button
+import android.widget.LinearLayout
 import android.widget.TextView
+import android.widget.Toast
 import androidx.appcompat.app.AlertDialog
 import androidx.appcompat.app.AppCompatActivity
 import com.smartfoo.android.core.logging.FooLog
+import kotlin.math.roundToInt
 
 class PersistentNotificationDialogActivity : AppCompatActivity() {
+    companion object {
+        private val TAG: String = FooLog.TAG(PersistentNotificationDialogActivity::class.java)
+
+        @JvmStatic
+        fun createIntent(context: Context): Intent =
+            Intent(context, PersistentNotificationDialogActivity::class.java)
+    }
 
     private var alertDialog: AlertDialog? = null
+    private val appPreferences by lazy { AppPreferences(applicationContext) }
 
     override fun onCreate(savedInstanceState: Bundle?) {
         FooLog.v(TAG, "+onCreate(savedInstanceState=$savedInstanceState)")
@@ -29,32 +44,87 @@ class PersistentNotificationDialogActivity : AppCompatActivity() {
     }
 
     private fun showPersistentDialog() {
-        val command = getString(R.string.alfred_notification_persistent_command)
-        val message = getString(R.string.alfred_notification_persistent_dialog_message, command)
+        val packageName = applicationContext.packageName
+        val command = getString(R.string.alfred_notification_persistent_command, packageName)
+        val message = getString(R.string.alfred_notification_persistent_dialog_message)
+
+        val density = resources.displayMetrics.density
+        val layout = LinearLayout(this).apply {
+            orientation = LinearLayout.VERTICAL
+            val horizontalPadding = (24 * density).roundToInt()
+            val topPadding = (24 * density).roundToInt()
+            val bottomPadding = (8 * density).roundToInt()
+            setPadding(horizontalPadding, topPadding, horizontalPadding, bottomPadding)
+        }
+
+        val messageView = TextView(this).apply {
+            text = message
+            setTextAppearance(android.R.style.TextAppearance_Material_Body1)
+        }
+        layout.addView(messageView)
+
+        val commandView = TextView(this).apply {
+            text = command
+            typeface = Typeface.MONOSPACE
+            setTextIsSelectable(true)
+            setTextAppearance(android.R.style.TextAppearance_Material_Body1)
+            val topPadding = (16 * density).roundToInt()
+            setPadding(0, topPadding, 0, 0)
+        }
+        commandView.isClickable = true
+        commandView.isFocusable = true
+        commandView.setOnClickListener { copyCommandToClipboard(command) }
+        layout.addView(commandView)
+
+        val copyButton = Button(this).apply {
+            text = getString(R.string.alfred_notification_persistent_copy_button)
+            setOnClickListener { copyCommandToClipboard(command) }
+        }
+        val buttonLayoutParams = LinearLayout.LayoutParams(
+            LinearLayout.LayoutParams.MATCH_PARENT,
+            LinearLayout.LayoutParams.WRAP_CONTENT,
+        ).apply {
+            topMargin = (12 * density).roundToInt()
+        }
+        layout.addView(copyButton, buttonLayoutParams)
 
         val dialog = AlertDialog.Builder(this)
             .setTitle(R.string.alfred_notification_persistent_dialog_title)
-            .setMessage(message)
+            .setView(layout)
             .setPositiveButton(android.R.string.ok) { dialogInterface, _ ->
                 dialogInterface.dismiss()
             }
+            .setNegativeButton(R.string.alfred_notification_persistent_ignore_button) { dialogInterface, _ ->
+                onIgnoreClicked()
+                dialogInterface.dismiss()
+            }
             .create()
-
-        dialog.setOnShowListener {
-            dialog.findViewById<TextView>(android.R.id.message)?.setTextIsSelectable(true)
-        }
         dialog.setOnDismissListener { finish() }
         dialog.show()
 
         alertDialog = dialog
     }
 
-    companion object {
-        private val TAG: String = FooLog.TAG(PersistentNotificationDialogActivity::class.java)
+    private fun copyCommandToClipboard(command: String) {
+        val clipboard = getSystemService(Context.CLIPBOARD_SERVICE) as? ClipboardManager
+        if (clipboard == null) {
+            FooLog.w(TAG, "Clipboard manager not available")
+            return
+        }
+        clipboard.setPrimaryClip(ClipData.newPlainText("Persistent notification command", command))
+    }
 
-        @JvmStatic
-        fun createIntent(context: Context): Intent =
-            Intent(context, PersistentNotificationDialogActivity::class.java)
+    private fun onIgnoreClicked() {
+        FooLog.i(TAG, "User chose to ignore persistent notification guidance")
+        appPreferences.setPersistentNotificationActionIgnored(true)
+
+        val application = MainApplication.getMainApplication(this)
+        application.alfredManager.refreshOngoingNotification()
+
+        Toast.makeText(
+            this,
+            R.string.alfred_notification_persistent_ignore_confirmation,
+            Toast.LENGTH_LONG,
+        ).show()
     }
 }
-

--- a/app/src/main/java/com/swooby/alfred/PersistentNotificationDialogActivity.kt
+++ b/app/src/main/java/com/swooby/alfred/PersistentNotificationDialogActivity.kt
@@ -1,0 +1,60 @@
+package com.swooby.alfred
+
+import android.content.Context
+import android.content.Intent
+import android.os.Bundle
+import android.widget.TextView
+import androidx.appcompat.app.AlertDialog
+import androidx.appcompat.app.AppCompatActivity
+import com.smartfoo.android.core.logging.FooLog
+
+class PersistentNotificationDialogActivity : AppCompatActivity() {
+
+    private var alertDialog: AlertDialog? = null
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        FooLog.v(TAG, "+onCreate(savedInstanceState=$savedInstanceState)")
+        super.onCreate(savedInstanceState)
+        showPersistentDialog()
+        FooLog.v(TAG, "-onCreate(savedInstanceState=$savedInstanceState)")
+    }
+
+    override fun onDestroy() {
+        FooLog.v(TAG, "+onDestroy()")
+        alertDialog?.setOnDismissListener(null)
+        alertDialog?.dismiss()
+        alertDialog = null
+        super.onDestroy()
+        FooLog.v(TAG, "-onDestroy()")
+    }
+
+    private fun showPersistentDialog() {
+        val command = getString(R.string.alfred_notification_persistent_command)
+        val message = getString(R.string.alfred_notification_persistent_dialog_message, command)
+
+        val dialog = AlertDialog.Builder(this)
+            .setTitle(R.string.alfred_notification_persistent_dialog_title)
+            .setMessage(message)
+            .setPositiveButton(android.R.string.ok) { dialogInterface, _ ->
+                dialogInterface.dismiss()
+            }
+            .create()
+
+        dialog.setOnShowListener {
+            dialog.findViewById<TextView>(android.R.id.message)?.setTextIsSelectable(true)
+        }
+        dialog.setOnDismissListener { finish() }
+        dialog.show()
+
+        alertDialog = dialog
+    }
+
+    companion object {
+        private val TAG: String = FooLog.TAG(PersistentNotificationDialogActivity::class.java)
+
+        @JvmStatic
+        fun createIntent(context: Context): Intent =
+            Intent(context, PersistentNotificationDialogActivity::class.java)
+    }
+}
+

--- a/app/src/main/res/menu/activity_main.xml
+++ b/app/src/main/res/menu/activity_main.xml
@@ -39,6 +39,13 @@
         />
 
     <item
+        android:id="@+id/action_show_persistent_notification_help"
+        android:title="@string/action_show_persistent_notification_help"
+        android:visible="false"
+        app:showAsAction="never"
+        />
+
+    <item
         android:id="@+id/action_text_to_speech"
         android:title="@string/action_text_to_speech"
         app:showAsAction="never"
@@ -98,6 +105,7 @@
         android:visible="false"
         app:showAsAction="never"
         />
+
         -->
 
 </menu>

--- a/app/src/main/res/values-night/themes.xml
+++ b/app/src/main/res/values-night/themes.xml
@@ -13,4 +13,8 @@
         <item name="android:statusBarColor">?attr/colorPrimaryVariant</item>
         <!-- Customize your theme here. -->
     </style>
+    <style name="Theme.Alfred.Dialog" parent="Theme.MaterialComponents.DayNight.Dialog">
+        <item name="windowActionBar">false</item>
+        <item name="windowNoTitle">true</item>
+    </style>
 </resources>

--- a/app/src/main/res/values/alfred.xml
+++ b/app/src/main/res/values/alfred.xml
@@ -1,8 +1,19 @@
 <?xml version="1.0" encoding="utf-8"?>
-<resources>
+<resources xmlns:tools="http://schemas.android.com/tools">
 
     <!-- Visual/Text & Audio/Phonetic representation of spoken phrases -->
     <string name="alfred_app_name">@string/app_name</string>
+
+    <string name="alfred_notification_action_quit">Quit</string>
+    <string name="alfred_notification_action_persistent">Pin</string>
+    <string name="alfred_notification_persistent_dialog_title">Pin Notification To Be Persistent</string>
+    <string name="alfred_notification_persistent_dialog_message">To pin the Notification to be persistent, run the following command from a computer with ADB access to the phone:</string>
+    <string name="alfred_notification_persistent_command" tools:ignore="TypographyDashes">adb shell appops set --uid %1$s SYSTEM_EXEMPT_FROM_DISMISSIBLE_NOTIFICATIONS allow</string>
+    <string name="alfred_notification_persistent_copy_button">Copy To Clipboard</string>
+    <string name="alfred_notification_persistent_command_copied_to_clipboard">Command copied to clipboard</string>
+    <string name="alfred_notification_persistent_ignore_button">Ignore</string>
+    <string name="alfred_notification_persistent_ignore_confirmation">Persistent action hidden. You can reopen this help from the app menu.</string>
+    <string name="action_show_persistent_notification_help">Persistent Notification</string>
 
     <string name="alfred_initializing">Initializing</string>
     <string name="alfred_running">Running</string>
@@ -35,7 +46,7 @@
     <string name="alfred_notification_access_not_enabled">Notification Access Not Enabled</string>
     <string name="alfred_notification_listener_bind_timeout">Notification Listener Bind Timeout</string>
     <string name="alfred_please_enable_notification_access_for_the_X_application">Please enable Notification Access for the \"%1$s\" application.</string>
-    <string name="alfred_please_reenable_notification_access_for_the_X_application">This usually happens after updating the app during development, and can sometimes persist until your device is rebooted. Please re-enable notification access for the \"%1$s\" application, or if the problem persists, restart your device.</string>
+    <string name="alfred_please_reenable_notification_access_for_the_X_application">This usually happens after updating the app during development, and can sometimes persist until your device is rebooted. Please disable and re-enable notification access for the \"%1$s\" application, or if the problem persists, restart your device.</string>
     <string name="alfred_visual_only_tap_to_configure">Tap to configure.</string>
 
     <!-- TODO:(pv) Better sentence concatenation strategy... -->

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -22,13 +22,6 @@
     <string name="action_text_to_speech">Text-To-Speech</string>
     <string name="action_debug_show_debug_log">Show Debug Log</string>
     <string name="action_debug_clear_debug_log">Clear Debug Log</string>
-    <string name="alfred_notification_action_quit">Quit</string>
-    <string name="alfred_notification_action_persistent">Persistent</string>
-    <string name="alfred_notification_persistent_dialog_title">Keep Alfred's notification persistent</string>
-    <string name="alfred_notification_persistent_command">adb shell appops set --uid com.swooby.alfred2017m2 SYSTEM_EXEMPT_FROM_DISMISSIBLE_NOTIFICATIONS allow</string>
-    <string name="alfred_notification_persistent_dialog_message">Run the following command from a computer with the Android Debug Bridge (ADB) to prevent Android from dismissing Alfred&apos;s ongoing notification:
-
-%1$s</string>
     <!--
     <string name="action_debug_disable_debug_mode">Disable Debug Mode</string>
     -->

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -23,6 +23,12 @@
     <string name="action_debug_show_debug_log">Show Debug Log</string>
     <string name="action_debug_clear_debug_log">Clear Debug Log</string>
     <string name="alfred_notification_action_quit">Quit</string>
+    <string name="alfred_notification_action_persistent">Persistent</string>
+    <string name="alfred_notification_persistent_dialog_title">Keep Alfred's notification persistent</string>
+    <string name="alfred_notification_persistent_command">adb shell appops set --uid com.swooby.alfred2017m2 SYSTEM_EXEMPT_FROM_DISMISSIBLE_NOTIFICATIONS allow</string>
+    <string name="alfred_notification_persistent_dialog_message">Run the following command from a computer with the Android Debug Bridge (ADB) to prevent Android from dismissing Alfred&apos;s ongoing notification:
+
+%1$s</string>
     <!--
     <string name="action_debug_disable_debug_mode">Disable Debug Mode</string>
     -->

--- a/app/src/main/res/values/themes.xml
+++ b/app/src/main/res/values/themes.xml
@@ -24,4 +24,9 @@
 
     <style name="Theme.Alfred.PopupOverlay" parent="ThemeOverlay.AppCompat.Dark" />
 
+    <style name="Theme.Alfred.Dialog" parent="Theme.MaterialComponents.DayNight.Dialog">
+        <item name="windowActionBar">false</item>
+        <item name="windowNoTitle">true</item>
+    </style>
+
 </resources>


### PR DESCRIPTION
## Summary
- add a "Persistent" action to the Alfred ongoing notification that opens a dialog explaining how to grant the SYSTEM_EXEMPT_FROM_DISMISSIBLE_NOTIFICATIONS app-op
- skip the action when the current ongoing notification already has the NO_DISMISS flag set
- add a dialog-themed activity, localized strings, and theme resources to display the ADB instructions

## Testing
- ./gradlew :app:assembleDebug *(fails: Unable to tunnel through proxy. Proxy returns "HTTP/1.1 403 Forbidden")*

------
https://chatgpt.com/codex/tasks/task_e_68d7b7d98e04833399c6ac02d61e8233