### PR TITLE
Add editable greeting preferences for Alfred

### DIFF
--- a/app/src/main/java/com/swooby/alfred/AlfredManager.kt
+++ b/app/src/main/java/com/swooby/alfred/AlfredManager.kt
@@ -6,6 +6,7 @@ import android.app.Activity
 import android.app.Application
 import android.content.Context
 import android.os.Message
+import android.provider.ContactsContract
 import android.service.notification.StatusBarNotification
 import android.speech.tts.TextToSpeech
 import androidx.annotation.StringRes
@@ -48,6 +49,7 @@ import com.swooby.alfred.notification.parsers.AbstractNotificationParser
 import com.swooby.alfred.notification.parsers.AlfredNotificationParser
 import java.util.EnumMap
 import java.util.concurrent.TimeUnit
+import kotlin.random.Random
 
 class AlfredManager(applicationContext: Context) {
 
@@ -126,7 +128,7 @@ class AlfredManager(applicationContext: Context) {
         //
         mListenerManager = FooListenerManager(this)
         mNotificationManager = NotificationManager(this.applicationContext)
-        mSayingsManager = SayingsManager(this.applicationContext)
+        mSayingsManager = SayingsManager(this.applicationContext, mAppPreferences)
         textToSpeechManager =
             TextToSpeechManager(this.applicationContext, object : TextToSpeechManagerConfiguration {
                 override fun getVoiceName(): String {
@@ -244,7 +246,17 @@ class AlfredManager(applicationContext: Context) {
     }
 
     fun speakGreeting() {
-        speak(true, mSayingsManager.goodPartOfDayUserNoun())
+        val storedUserName = mAppPreferences.userName()
+        val effectiveUserName = storedUserName ?: getLoggedInUserName()?.also {
+            mAppPreferences.setUserName(it)
+        }
+        val shouldUseUserName = !effectiveUserName.isNullOrEmpty() && Random.nextBoolean()
+        val greetingBuilder = if (shouldUseUserName) {
+            mSayingsManager.goodPartOfDayUserName(effectiveUserName)
+        } else {
+            mSayingsManager.goodPartOfDayUserNoun()
+        }
+        speak(true, greetingBuilder)
     }
 
     //
@@ -401,6 +413,37 @@ class AlfredManager(applicationContext: Context) {
 
     private fun isPermissionGranted(permission: String): Boolean {
         return FooPermissionsChecker.isPermissionGranted(applicationContext, permission)
+    }
+
+    fun getLoggedInUserName(): String? {
+        val hasReadContactsPermission = isPermissionGranted(Manifest.permission.READ_CONTACTS)
+        val hasReadProfilePermission = isPermissionGranted(Manifest.permission.READ_PROFILE)
+        if (!hasReadContactsPermission && !hasReadProfilePermission) {
+            FooLog.v(TAG, "getLoggedInUserName: profile permissions not granted")
+            return null
+        }
+
+        return try {
+            applicationContext.contentResolver.query(
+                ContactsContract.Profile.CONTENT_URI,
+                arrayOf(ContactsContract.Profile.DISPLAY_NAME),
+                null,
+                null,
+                null,
+            )?.use { cursor ->
+                if (cursor.moveToFirst()) {
+                    cursor.getString(0)?.trim()?.takeIf { it.isNotEmpty() }
+                } else {
+                    null
+                }
+            }
+        } catch (securityException: SecurityException) {
+            FooLog.w(TAG, "getLoggedInUserName: unable to query profile", securityException)
+            null
+        } catch (throwable: Throwable) {
+            FooLog.e(TAG, "getLoggedInUserName: unexpected failure", throwable)
+            null
+        }
     }
 
     fun attach(callbacks: AlfredManagerCallbacks) {

--- a/app/src/main/java/com/swooby/alfred/AppPreferences.kt
+++ b/app/src/main/java/com/swooby/alfred/AppPreferences.kt
@@ -20,6 +20,8 @@ class AppPreferences(applicationContext: Context?)
         private const val KEY_USER_KEYPHRASE = "pref_user_keyphrase"
         private const val KEY_USER_PERSISTENT_NOTIFICATION_ACTION_IGNORED =
             "pref_user_persistent_notification_action_ignored"
+        private const val KEY_USER_NAME = "pref_user_name"
+        private const val KEY_USER_GENDER = "pref_user_gender"
     }
 
     init {
@@ -106,6 +108,50 @@ class AppPreferences(applicationContext: Context?)
             FILE_NAME_USER,
             KEY_USER_PERSISTENT_NOTIFICATION_ACTION_IGNORED,
             value
+        )
+    }
+
+    fun userName(): String? {
+        val storedValue = getString(
+            FILE_NAME_USER,
+            KEY_USER_NAME,
+            ""
+        )
+        val trimmedValue = storedValue?.trim()
+        return if (trimmedValue.isNullOrEmpty()) {
+            null
+        } else {
+            trimmedValue
+        }
+    }
+
+    fun setUserName(value: String?) {
+        val trimmedValue = value?.trim().orEmpty()
+        setString(
+            FILE_NAME_USER,
+            KEY_USER_NAME,
+            trimmedValue
+        )
+    }
+
+    fun userGender(): SayingsManager.Gender {
+        val storedValue = getString(
+            FILE_NAME_USER,
+            KEY_USER_GENDER,
+            SayingsManager.Gender.Unspecified.name
+        )
+        return try {
+            SayingsManager.Gender.valueOf(storedValue ?: SayingsManager.Gender.Unspecified.name)
+        } catch (ignored: IllegalArgumentException) {
+            SayingsManager.Gender.Unspecified
+        }
+    }
+
+    fun setUserGender(value: SayingsManager.Gender) {
+        setString(
+            FILE_NAME_USER,
+            KEY_USER_GENDER,
+            value.name
         )
     }
 }

--- a/app/src/main/java/com/swooby/alfred/MainActivity.kt
+++ b/app/src/main/java/com/swooby/alfred/MainActivity.kt
@@ -12,19 +12,23 @@ import android.speech.tts.Voice
 import android.view.Menu
 import android.view.MenuItem
 import android.view.View
+import android.view.ViewGroup
 import android.widget.AdapterView
 import android.widget.ArrayAdapter
 import android.widget.Button
 import android.widget.SeekBar
 import android.widget.SeekBar.OnSeekBarChangeListener
+import android.widget.TextView
 import androidx.activity.OnBackPressedCallback
 import androidx.appcompat.app.ActionBarDrawerToggle
 import androidx.appcompat.app.AppCompatActivity
 import androidx.core.app.ActivityCompat
 import androidx.core.view.GravityCompat
+import androidx.core.widget.doOnTextChanged
 import androidx.drawerlayout.widget.DrawerLayout
 import androidx.fragment.app.DialogFragment
 import com.google.android.material.navigation.NavigationView
+import com.google.android.material.textfield.TextInputEditText
 import com.smartfoo.android.core.FooString
 import com.smartfoo.android.core.app.FooDebugActivity
 import com.smartfoo.android.core.app.FooDebugConfiguration
@@ -119,6 +123,8 @@ class MainActivity
 
     private lateinit var binding: ActivityMainBinding
 
+    private lateinit var mEditTextUserName: TextInputEditText
+    private lateinit var mSpinnerUserGender: UserTouchSpinner
     private lateinit var mSpinnerTextToSpeechVoices: UserTouchSpinner
     private lateinit var mSeekbarTextToSpeechVoiceSpeed: SeekBar
     private lateinit var mSeekbarTextToSpeechVoicePitch: SeekBar
@@ -302,6 +308,67 @@ class MainActivity
             }
 
             override fun onStopTrackingTouch(seekBar: SeekBar) {
+            }
+        })
+
+        mEditTextUserName = binding.appBarMain.activityMainContent.editTextUserName
+        val storedUserName = mAppPreferences.userName()
+        val defaultUserName = storedUserName ?: mAlfredManager.getLoggedInUserName()
+        if (storedUserName.isNullOrEmpty() && !defaultUserName.isNullOrEmpty()) {
+            mAppPreferences.setUserName(defaultUserName)
+        }
+        mEditTextUserName.setText(defaultUserName ?: "")
+        mEditTextUserName.doOnTextChanged { text, _, _, _ ->
+            val updatedName = text?.toString()?.trim()
+            if (updatedName != mAppPreferences.userName()) {
+                mAppPreferences.setUserName(updatedName)
+            }
+        }
+
+        mSpinnerUserGender = binding.appBarMain.activityMainContent.spinnerUserGender
+        val genderValues = SayingsManager.Gender.values()
+        val genderAdapter = object : ArrayAdapter<SayingsManager.Gender>(
+            this,
+            android.R.layout.simple_spinner_item,
+            genderValues
+        ) {
+            override fun getView(position: Int, convertView: View?, parent: ViewGroup): View {
+                val view = super.getView(position, convertView, parent) as TextView
+                view.text = getString(genderValues[position].getDisplayNameResId())
+                return view
+            }
+
+            override fun getDropDownView(position: Int, convertView: View?, parent: ViewGroup): View {
+                val view = super.getDropDownView(position, convertView, parent) as TextView
+                view.text = getString(genderValues[position].getDisplayNameResId())
+                return view
+            }
+        }
+        genderAdapter.setDropDownViewResource(android.R.layout.simple_spinner_dropdown_item)
+        mSpinnerUserGender.adapter = genderAdapter
+        val initialGender = mAppPreferences.userGender()
+        val selectedGenderIndex = genderValues.indexOf(initialGender).takeIf { it >= 0 } ?: 0
+        mSpinnerUserGender.setSelection(selectedGenderIndex)
+        if (genderValues.getOrNull(selectedGenderIndex) != initialGender) {
+            mAppPreferences.setUserGender(genderValues[selectedGenderIndex])
+        }
+        mSpinnerUserGender.setOnItemSelectedListener(object : UserTouchSpinner.OnItemSelectedListener {
+            override fun onItemSelected(
+                parent: AdapterView<*>,
+                view: View?,
+                position: Int,
+                id: Long,
+                fromUser: Boolean
+            ) {
+                if (fromUser) {
+                    val selectedGender = parent.adapter.getItem(position) as SayingsManager.Gender
+                    if (selectedGender != mAppPreferences.userGender()) {
+                        mAppPreferences.setUserGender(selectedGender)
+                    }
+                }
+            }
+
+            override fun onNothingSelected(parent: AdapterView<*>, fromUser: Boolean) {
             }
         })
 

--- a/app/src/main/java/com/swooby/alfred/SayingsManager.java
+++ b/app/src/main/java/com/swooby/alfred/SayingsManager.java
@@ -4,9 +4,11 @@ import android.content.Context;
 import android.icu.util.Calendar;
 
 import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
 import androidx.annotation.StringRes;
 
 import com.smartfoo.android.core.texttospeech.FooTextToSpeechBuilder;
+import com.smartfoo.android.core.FooString;
 
 import java.util.Random;
 
@@ -27,11 +29,13 @@ public class SayingsManager
     }
 
     private final Context mContext;
+    private final AppPreferences mAppPreferences;
     private final Random  mRandom;
 
-    SayingsManager(@NonNull Context context)
+    SayingsManager(@NonNull Context context, @NonNull AppPreferences appPreferences)
     {
         mContext = context;
+        mAppPreferences = appPreferences;
         mRandom = new Random();
     }
 
@@ -79,30 +83,46 @@ public class SayingsManager
 
     public enum Gender
     {
-        Male,
-        Female,
+        Unspecified(R.string.user_gender_unspecified),
+        Male(R.string.user_gender_male),
+        Female(R.string.user_gender_female);
+
+        @StringRes
+        private final int mDisplayNameResId;
+
+        Gender(@StringRes int displayNameResId)
+        {
+            mDisplayNameResId = displayNameResId;
+        }
+
+        @StringRes
+        int getDisplayNameResId()
+        {
+            return mDisplayNameResId;
+        }
     }
 
     private String userPronoun(Formality formality)
     {
         formality = formalityOrRandomFormality(formality);
 
-        // TODO:(pv) Settable or pull from settings...
-        Gender gender = Gender.Male;
+        Gender gender = mAppPreferences.userGender();
 
         switch (gender)
         {
             case Male:
-                return "Sir";
+                return mContext.getString(R.string.user_pronoun_male);
             case Female:
                 switch (formality)
                 {
                     case Frozen:
                     case Formal:
-                        return "Madam";
+                        return mContext.getString(R.string.user_pronoun_female_formal);
                     default:
-                        return "Ma'am";
+                        return mContext.getString(R.string.user_pronoun_female_casual);
                 }
+            case Unspecified:
+                return mContext.getString(R.string.user_pronoun_unspecified);
             default:
                 throw new IllegalArgumentException("Unexpected gender == " + gender);
         }
@@ -110,8 +130,7 @@ public class SayingsManager
 
     private String userName()
     {
-        // TODO:(pv) Settable or pull from settings...
-        return "Paul";
+        return mAppPreferences.userName();
     }
 
     private String userNoun()
@@ -130,7 +149,12 @@ public class SayingsManager
                 return userPronoun(formality);
             case Casual:
             case Intimate:
-                return userName();
+                String userName = userName();
+                if (FooString.isNullOrEmpty(userName))
+                {
+                    return userPronoun(formality);
+                }
+                return userName;
             default:
                 throw new IllegalArgumentException("Unexpected formality == " + formality);
         }
@@ -138,39 +162,75 @@ public class SayingsManager
 
     FooTextToSpeechBuilder goodPartOfDayUserNoun()
     {
+        return goodPartOfDayUser(userNoun(FORMALITY_DEFAULT));
+    }
+
+    FooTextToSpeechBuilder goodPartOfDayUserName(@Nullable String userName)
+    {
+        if (userName == null)
+        {
+            return goodPartOfDayUserNoun();
+        }
+
+        String trimmedUserName = userName.trim();
+        if (trimmedUserName.isEmpty())
+        {
+            return goodPartOfDayUserNoun();
+        }
+
+        return goodPartOfDayUser(trimmedUserName);
+    }
+
+    private FooTextToSpeechBuilder goodPartOfDayUser(@NonNull String user)
+    {
         FooTextToSpeechBuilder builder;
         int hourOfDay = Calendar.getInstance().get(Calendar.HOUR_OF_DAY);
         // TODO:(pv) Make these settable?
         if (hourOfDay > 18) // 6PM
         {
-            builder = goodEveningUserNoun();
+            builder = goodEveningUser(user);
         }
         else if (hourOfDay > 12) // 12PM
         {
-            builder = goodAfternoonUserNoun();
+            builder = goodAfternoonUser(user);
         }
         else
         {
-            builder = goodMorningUserNoun();
+            builder = goodMorningUser(user);
         }
         return builder;
     }
 
     private FooTextToSpeechBuilder goodMorningUserNoun()
     {
-        return new FooTextToSpeechBuilder(mContext)
-                .appendSpeech("Good morning " + userNoun(FORMALITY_DEFAULT));
+        return goodMorningUser(userNoun(FORMALITY_DEFAULT));
     }
 
     private FooTextToSpeechBuilder goodAfternoonUserNoun()
     {
-        return new FooTextToSpeechBuilder(mContext)
-                .appendSpeech("Good afternoon " + userNoun(FORMALITY_DEFAULT));
+        return goodAfternoonUser(userNoun(FORMALITY_DEFAULT));
     }
 
     private FooTextToSpeechBuilder goodEveningUserNoun()
     {
+        return goodEveningUser(userNoun(FORMALITY_DEFAULT));
+    }
+
+    private FooTextToSpeechBuilder goodMorningUser(@NonNull String user)
+    {
         return new FooTextToSpeechBuilder(mContext)
-                .appendSpeech("Good evening " + userNoun(FORMALITY_DEFAULT));
+                .appendSpeech("Good morning " + user);
+    }
+
+    private FooTextToSpeechBuilder goodAfternoonUser(@NonNull String user)
+    {
+        return new FooTextToSpeechBuilder(mContext)
+                .appendSpeech("Good afternoon " + user);
+    }
+
+    private FooTextToSpeechBuilder goodEveningUser(@NonNull String user)
+    {
+        return new FooTextToSpeechBuilder(mContext)
+                .appendSpeech("Good evening " + user);
     }
 }

--- a/app/src/main/res/layout/activity_main_content.xml
+++ b/app/src/main/res/layout/activity_main_content.xml
@@ -209,6 +209,50 @@
 
         </TableRow>
 
+        <TableRow
+            android:layout_marginTop="16dp">
+
+            <com.google.android.material.textfield.TextInputLayout
+                android:id="@+id/textInputLayoutUserName"
+                android:layout_width="0dp"
+                android:layout_height="wrap_content"
+                android:layout_span="2"
+                android:layout_weight="1"
+                android:hint="@string/user_name_label">
+
+                <com.google.android.material.textfield.TextInputEditText
+                    android:id="@+id/editTextUserName"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:imeOptions="actionDone"
+                    android:inputType="textPersonName"
+                    android:singleLine="true" />
+
+            </com.google.android.material.textfield.TextInputLayout>
+
+            <LinearLayout
+                android:layout_width="0dp"
+                android:layout_height="wrap_content"
+                android:layout_weight="1"
+                android:orientation="vertical"
+                android:paddingStart="16dp">
+
+                <TextView
+                    android:id="@+id/textViewUserGenderLabel"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:text="@string/user_gender_label"
+                    android:textStyle="bold" />
+
+                <com.swooby.alfred.UserTouchSpinner
+                    android:id="@+id/spinnerUserGender"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content" />
+
+            </LinearLayout>
+
+        </TableRow>
+
         <TableRow android:layout_marginTop="16dp">
 
             <TextView

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -41,6 +41,15 @@
     <string name="process_notifications">Process Notifications</string>
     <string name="text_to_speech_test">TextToSpeech: Test</string>
     <string name="text_to_speech_stop_clear">TextToSpeech: Stop/Clear</string>
+    <string name="user_name_label">Name</string>
+    <string name="user_gender_label">Gender</string>
+    <string name="user_gender_unspecified">Prefer not to say</string>
+    <string name="user_gender_male">Male</string>
+    <string name="user_gender_female">Female</string>
+    <string name="user_pronoun_male">Sir</string>
+    <string name="user_pronoun_female_formal">Madam</string>
+    <string name="user_pronoun_female_casual">Ma'am</string>
+    <string name="user_pronoun_unspecified">friend</string>
 
     <!-- Profile names: May these ever be spoken? -->
     <string name="profile_disabled">Disabled</string>


### PR DESCRIPTION
## Summary
- add stored user name and gender preferences with corresponding inputs in MainActivity
- update SayingsManager to honor the saved identity information when constructing greetings
- have AlfredManager reuse the stored or profile-derived user name when speaking its greeting

## Testing
- ./gradlew :app:testDebugUnitTest *(fails: proxy 403 while downloading Gradle)*

------
https://chatgpt.com/codex/tasks/task_e_68d8bb9e35588333b0fb985546192d2f